### PR TITLE
Fix #15: Implement protocol 3.7

### DIFF
--- a/msgs/festartupmsg.go
+++ b/msgs/festartupmsg.go
@@ -49,8 +49,13 @@ type FEStartupMsg struct {
 func (m *FEStartupMsg) Flatten() ([]byte, byte) {
 
 	buf := newMsgBuffer()
+	const fixedProtocolVersion uint32 = 0x00030005
+	buf.appendUint32(fixedProtocolVersion)
 
+	// Requested protocol version
+	buf.appendString("protocol_version")
 	buf.appendUint32(m.ProtocolVersion)
+	buf.appendBytes([]byte{0})
 
 	if len(m.Username) > 0 {
 		buf.appendLabeledString("user", m.Username)


### PR DESCRIPTION
#15 mentioned client backward compatibility (protocol 3.7) is missing. Add it now.


Manually test the connection with the following server versions:
- v8.0.1
- v8.1.1
- v9.0.0