### PR TITLE
Fix bug involving null columns.

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -680,6 +680,7 @@ var tlsMode = flag.String("tlsmode", "none", "SSL/TLS mode (none, server, server
 var usePreparedStmts = flag.Bool("use_prepared_statements", true, "whether to use prepared statements for all queries/executes")
 
 func init() {
+	flag.Parse()
 	testLogger.Info("user name: %s", *verticaUserName)
 	testLogger.Info("password : **********")
 	testLogger.Info("locator  : %s", *verticaHostPort)

--- a/driver_test.go
+++ b/driver_test.go
@@ -438,36 +438,40 @@ func TestValueTypes(t *testing.T) {
 	assertEqual(t, numericVal, 1.2345)
 
 	assertNext(t, rows)
-	nils := make([]interface{}, 13)
-	assertNoErr(t, rows.Scan(&nils[0], &nils[1], &nils[2], &nils[3], &nils[4], &nils[5], &nils[6], &nils[7],
-		&nils[8], &nils[9], &nils[10], &nils[11], &nils[12]))
 
-	_, ok := nils[0].(sql.NullBool)
-	assertTrue(t, ok)
-	_, ok = nils[1].(sql.NullInt64)
-	assertTrue(t, ok)
-	_, ok = nils[2].(sql.NullFloat64)
-	assertTrue(t, ok)
-	_, ok = nils[3].(sql.NullString)
-	assertTrue(t, ok)
-	_, ok = nils[4].(sql.NullString)
-	assertTrue(t, ok)
-	_, ok = nils[5].(sql.NullString)
-	assertTrue(t, ok)
-	_, ok = nils[6].(sql.NullString)
-	assertTrue(t, ok)
-	_, ok = nils[7].(sql.NullString)
-	assertTrue(t, ok)
-	_, ok = nils[8].(sql.NullString)
-	assertTrue(t, ok)
-	_, ok = nils[9].(sql.NullString)
-	assertTrue(t, ok)
-	_, ok = nils[10].(sql.NullString)
-	assertTrue(t, ok)
-	_, ok = nils[11].(sql.NullString)
-	assertTrue(t, ok)
-	_, ok = nils[12].(sql.NullFloat64)
-	assertTrue(t, ok)
+	var (
+		nullBoolVal        sql.NullBool
+		nullIntVal         sql.NullInt64
+		nullFloatVal       sql.NullFloat64
+		nullCharVal        sql.NullString
+		nullVarCharVal     sql.NullString
+		nullTimestampVal   sql.NullString
+		nullTimestampTZVal sql.NullString
+		nullVarBinVal      sql.NullString
+		nullUuidVal        sql.NullString
+		nullLVarCharVal    sql.NullString
+		nullLVarBinaryVal  sql.NullString
+		nullBinaryVal      sql.NullString
+		nullNumericVal     sql.NullFloat64
+	)
+
+	assertNoErr(t, rows.Scan(&nullBoolVal, &nullIntVal, &nullFloatVal, &nullCharVal,
+		&nullVarCharVal, &nullTimestampVal, &nullTimestampTZVal, &nullVarBinVal, &nullUuidVal,
+		&nullLVarCharVal, &nullLVarBinaryVal, &nullBinaryVal, &nullNumericVal))
+
+	assertTrue(t, !nullBoolVal.Valid)
+	assertTrue(t, !nullIntVal.Valid)
+	assertTrue(t, !nullFloatVal.Valid)
+	assertTrue(t, !nullCharVal.Valid)
+	assertTrue(t, !nullVarCharVal.Valid)
+	assertTrue(t, !nullTimestampVal.Valid)
+	assertTrue(t, !nullTimestampTZVal.Valid)
+	assertTrue(t, !nullVarBinVal.Valid)
+	assertTrue(t, !nullUuidVal.Valid)
+	assertTrue(t, !nullLVarCharVal.Valid)
+	assertTrue(t, !nullLVarBinaryVal.Valid)
+	assertTrue(t, !nullBinaryVal.Valid)
+	assertTrue(t, !nullNumericVal.Valid)
 
 	assertNoErr(t, rows.Close())
 }
@@ -607,7 +611,7 @@ func TestSTDINCopy(t *testing.T) {
 	_, err = connDB.ExecContext(ctx, "COPY stdin_data FROM STDIN DELIMITER ','")
 	assertNoErr(t, err)
 
-	rows, err := connDB.QueryContext(ctx, "SELECT * FROM stdin_data")
+	rows, err := connDB.QueryContext(ctx, "SELECT name,id FROM stdin_data as t(name,id) order by name")
 	assertNoErr(t, err)
 
 	defer rows.Close()
@@ -615,8 +619,8 @@ func TestSTDINCopy(t *testing.T) {
 	columns, _ := rows.Columns()
 	assertEqual(t, len(columns), 2)
 
-	names := []string{"roger", "siting", "tom", "yang", "john"}
-	ids := []int{123, 456, 789, 333, 555}
+	names := []string{"john", "roger", "siting", "tom", "yang"}
+	ids := []int{555, 123, 456, 789, 333}
 	matched := 0
 	var name string
 	var id int
@@ -648,7 +652,7 @@ func TestSTDINCopyWithStream(t *testing.T) {
 	_, err = connDB.ExecContext(vCtx, "COPY stdin_data FROM STDIN DELIMITER ','")
 	assertNoErr(t, err)
 
-	rows, err := connDB.QueryContext(ctx, "SELECT * FROM stdin_data")
+	rows, err := connDB.QueryContext(ctx, "SELECT name,id FROM stdin_data as t(name,id) order by name")
 	assertNoErr(t, err)
 
 	defer rows.Close()
@@ -656,8 +660,8 @@ func TestSTDINCopyWithStream(t *testing.T) {
 	columns, _ := rows.Columns()
 	assertEqual(t, len(columns), 2)
 
-	names := []string{"roger", "siting", "tom", "yang", "john"}
-	ids := []int{123, 456, 789, 333, 555}
+	names := []string{"john", "roger", "siting", "tom", "yang"}
+	ids := []int{555, 123, 456, 789, 333}
 	matched := 0
 	var name string
 	var id int
@@ -680,7 +684,10 @@ var tlsMode = flag.String("tlsmode", "none", "SSL/TLS mode (none, server, server
 var usePreparedStmts = flag.Bool("use_prepared_statements", true, "whether to use prepared statements for all queries/executes")
 
 func init() {
-	flag.Parse()
+	// One or both lines below are necessary depending on your go version
+	// testing.Init()
+	// flag.Parse()
+
 	testLogger.Info("user name: %s", *verticaUserName)
 	testLogger.Info("password : **********")
 	testLogger.Info("locator  : %s", *verticaHostPort)

--- a/rows.go
+++ b/rows.go
@@ -33,7 +33,6 @@ package vertigo
 // THE SOFTWARE.
 
 import (
-	"database/sql"
 	"database/sql/driver"
 	"encoding/hex"
 	"fmt"
@@ -88,60 +87,31 @@ func (r *rows) Next(dest []driver.Value) error {
 	thisRow := r.resultData[r.readIndex]
 
 	for idx, colVal := range thisRow.RowData {
-
+		if colVal == nil {
+			dest[idx] = nil
+			continue
+		}
 		switch r.columnDefs.Columns[idx].DataTypeOID {
 		case common.ColTypeBoolean: // to boolean
-			if colVal == nil {
-				dest[idx] = sql.NullBool{}
+			if colVal[0] == 't' {
+				dest[idx] = true
 			} else {
-				if colVal[0] == 't' {
-					dest[idx] = true
-				} else {
-					dest[idx] = false
-				}
+				dest[idx] = false
 			}
 		case common.ColTypeInt64: // to integer
-			if colVal == nil {
-				dest[idx] = sql.NullInt64{}
-			} else {
-				dest[idx], _ = strconv.Atoi(string(colVal))
-			}
+			dest[idx], _ = strconv.Atoi(string(colVal))
 		case common.ColTypeVarChar, common.ColTypeLongVarChar, common.ColTypeChar, common.ColTypeUUID: // stays string, convert char to string
-			if colVal == nil {
-				dest[idx] = sql.NullString{}
-			} else {
-				dest[idx] = string(colVal)
-			}
+			dest[idx] = string(colVal)
 		case common.ColTypeFloat64, common.ColTypeNumeric: // to float64
-			if colVal == nil {
-				dest[idx] = sql.NullFloat64{}
-			} else {
-				dest[idx], _ = strconv.ParseFloat(string(colVal), 64)
-			}
+			dest[idx], _ = strconv.ParseFloat(string(colVal), 64)
 		case common.ColTypeTimestamp: // to time.Time from YYYY-MM-DD hh:mm:ss
-			if colVal == nil {
-				dest[idx] = sql.NullString{}
-			} else {
-				dest[idx], _ = parseTimestampTZColumn(string(colVal) + r.tzOffset)
-			}
+			dest[idx], _ = parseTimestampTZColumn(string(colVal) + r.tzOffset)
 		case common.ColTypeTimestampTZ:
-			if colVal == nil {
-				dest[idx] = sql.NullString{}
-			} else {
-				dest[idx], _ = parseTimestampTZColumn(string(colVal))
-			}
+			dest[idx], _ = parseTimestampTZColumn(string(colVal))
 		case common.ColTypeVarBinary, common.ColTypeLongVarBinary, common.ColTypeBinary: // to []byte - this one's easy
-			if colVal == nil {
-				dest[idx] = sql.NullString{}
-			} else {
-				dest[idx] = hex.EncodeToString(colVal)
-			}
+			dest[idx] = hex.EncodeToString(colVal)
 		default:
-			if colVal == nil {
-				dest[idx] = sql.NullString{}
-			} else {
-				dest[idx] = string(colVal)
-			}
+			dest[idx] = string(colVal)
 		}
 	}
 


### PR DESCRIPTION
In using the vertica driver, I was getting a "syntax invalid" error trying to rows.Scan() a column that had a null value.

Looking at rows.go, I think the use of sql.NullInt64, et al types were not used correctly. The sql.NullX types are structs with the type plus a bool to indicate if it's null or not. The way they're used in rows.go, it looks like it's used as though it *means* the field is null. 

The database/sql interface expects you to either set your columns to nil or set them to their actual value and it handles conversion to an sql.NullX type.

I made a little test program to demonstrate:


```go
package main

import (
	"database/sql"
	"fmt"
	//	_ "github.com/vertica/vertica-sql-go"
	_ "github.com/deusnefum/vertica-sql-go"
)

func main() {
	db, err := sql.Open("vertica", "vertica://dbadmin:SuperFantasticPassword@localhost:5433/dbadmin")
	if err != nil {
		panic(err)
	}

	rows, err := db.Query("SELECT 'tom' AS name, null AS id, null AS ncol")
	if err != nil {
		panic(err)
	}

	var n string
	var i sql.NullInt64
	var q sql.NullString

	for rows.Next() {
		rows.Scan(&n, &i, &q)
	}

	fmt.Println(n, i, q)
}
```

When I use the upstream code I get this:

> tom {0 true} { false}

The second col, id, was null. The value should've been {0 false}.

When I used my fixed code:

>  tom {0 false} { false}

I also ran the driver_test.go file and all passed except for an error with testSTDINCopy, which I don't think is related to my change. To get the flags to work, I had to add flags.Parse() to init, which fixes https://github.com/vertica/vertica-sql-go/issues/33.