### PR TITLE
Fix transaction isolation level syntax

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -310,6 +310,7 @@ func TestTransaction(t *testing.T) {
 	assertNoErr(t, err)
 	assertNoErr(t, tx.Commit())
 
+	opts.Isolation = sql.LevelReadCommitted
 	tx, err = connDB.BeginTx(ctx, opts)
 	assertNoErr(t, err)
 	assertNoErr(t, tx.Rollback())

--- a/tx.go
+++ b/tx.go
@@ -83,13 +83,13 @@ func newTransaction(ctx context.Context, c *connection, opts driver.TxOptions) (
 
 	switch sql.IsolationLevel(opts.Isolation) {
 	case sql.LevelReadUncommitted:
-		queryStr += " READ UNCOMMITTED"
+		queryStr += " ISOLATION LEVEL READ UNCOMMITTED"
 	case sql.LevelReadCommitted:
-		queryStr += " READ COMMITTED"
+		queryStr += " ISOLATION LEVEL READ COMMITTED"
 	case sql.LevelSerializable:
-		queryStr += " SERIALIZABLE"
+		queryStr += " ISOLATION LEVEL SERIALIZABLE"
 	case sql.LevelRepeatableRead:
-		queryStr += " REPEATABLE READ"
+		queryStr += " ISOLATION LEVEL REPEATABLE READ"
 	case sql.LevelDefault:
 		break
 	default:


### PR DESCRIPTION
The previous code would fail with `Syntax error at or near \"COMMITTED\"`.

See https://www.vertica.com/docs/9.2.x/HTML/Content/Authoring/SQLReferenceManual/Statements/STARTTRANSACTION.htm?TocPath=SQL%20Reference%20Manual%7CSQL%20Statements%7C_____37