### PR TITLE
Logger Improvements

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -36,7 +36,6 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"time"
 )
 
 // LogLevel is the enum type for the log levels.
@@ -54,12 +53,12 @@ const (
 
 // Backend defines the public interface that must be implemented by all logger backends
 type Backend interface {
-	write(logStr string)
-	close()
+	Write(prefix string, name string, msg string)
+	Close()
 }
 
 var (
-	prefixes         = []string{"TRACE", "DEBUG", "INFO ", "WARN ", "ERROR", "FATAL"}
+	prefixes         = []string{"TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"}
 	level            = WARN
 	logger   Backend = &STDIOLogger{}
 )
@@ -69,9 +68,7 @@ type Logger struct {
 }
 
 func (l *Logger) print(level LogLevel, format string, args ...interface{}) {
-	logger.write(time.Now().Format(time.StampMicro))
-	logger.write(fmt.Sprintf(" %s %s: ", prefixes[level], l.name))
-	logger.write(fmt.Sprintf(format+"\n", args...))
+	logger.Write(prefixes[level], l.name, fmt.Sprintf(format, args...))
 }
 
 func New(name string) *Logger {
@@ -133,7 +130,7 @@ func SetLogLevel(newLevel LogLevel) {
 
 func SetLogger(newLogger Backend) {
 	if logger != newLogger {
-		logger.close()
+		logger.Close()
 		logger = newLogger
 	}
 }

--- a/logger/stdiologger.go
+++ b/logger/stdiologger.go
@@ -32,14 +32,20 @@ package logger
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import "os"
+import (
+	"fmt"
+	"os"
+	"time"
+)
 
 type STDIOLogger struct {
 }
 
-func (l *STDIOLogger) write(logStr string) {
-	os.Stdout.Write([]byte(logStr))
+func (l *STDIOLogger) Write(prefix string, name string, msg string) {
+	os.Stdout.Write([]byte(time.Now().Format(time.StampMicro)))
+	os.Stdout.Write([]byte(fmt.Sprintf(" %s %s: ", prefix, name)))
+	os.Stdout.Write([]byte(msg + "\n"))
 }
 
-func (l *STDIOLogger) close() {
+func (l *STDIOLogger) Close() {
 }


### PR DESCRIPTION
(1) allow the logger backend to be implemented externally
(2) making logger.Backend.Write more generic

Thoughts? I would like to handle what the logger does inside my application. E.g. I want to format the message a particular way. If we change the interface slightly, applications can define their own logging backend.