### PR TITLE
Add unit tests for interpolate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,17 @@ vertica-sql-go has been tested with Vertica 9.2.0+ and Go 1.11.2.
 
 * As this driver is still in alpha stage, we reserve the right to break APIs and change functionality until it has been stablilized.
 
-
 ## Installation
 
 Source code for vertica-sql-go can be found at:
 
-    https://github.com/vertica/vertica-sql-go
+https://github.com/vertica/vertica-sql-go
 
 Alternatively you can use the 'go get' variant to install the package into your local Go environment.
 
 ```sh
 go get github.com/vertica/vertica-sql-go
 ```
-
 
 ## Usage
 
@@ -61,21 +59,26 @@ The vertica-sql-go driver supports multiple log levels, as defined in the follow
 | 6               | NONE           | Disable all log messages |
 
 and they can be set programmatically by calling the logger global level itself
+
 ```Go
 logger.SetLogLevel(logger.DEBUG)
 ```
+
 or by setting the environment variable VERTICA_SQL_GO_LOG_LEVEL to one of the integer values in the table above. This must be done before the process using the driver has started as the global log level will be read from here on start-up.
 
 Example:
+
 ```bash
 export VERTICA_SQL_GO_LOG_LEVEL=3
 ```
+
 ### Setting the Log File
 
 By default, log messages are sent to stdout, but the vertica-sql-go driver can also output to a file in cases where stdout is not available.
 Simply set the environment variable VERTICA_SQL_GO_LOG_FILE to your desired output location.
 
 Example:
+
 ```bash
 export VERTICA_SQL_GO_LOG_FILE=/var/log/vertica-sql-go.log
 ``` 
@@ -85,11 +88,13 @@ export VERTICA_SQL_GO_LOG_FILE=/var/log/vertica-sql-go.log
 ```Go
 connDB, err := sql.Open("vertica", myDBConnectString)
 ```
+
 where *myDBConnectString* is of the form:
 
-```
+```Go
 vertica://(user):(password)@(host):(port)/(database)?(queryArgs)
 ```
+
 Currently supported query arguments are:
 
 | Query Argument | Description | Values |
@@ -137,7 +142,7 @@ With client interpolation enabled, the client library will create a new query st
 
 With client interpolation disabled (default), the client library will use the full server-side parse(), describe(), bind(), execute() cycle.
 
-### Reading query result rows.
+### Reading query result rows
 
 As outlined in the GoLang specs, reading the results of a query is done via a loop, bounded by a .next() iterator.
 
@@ -163,6 +168,7 @@ for _, columnName := range columnNames {
         // use the column name here.
 }
 ```
+
 ### Paging in Data
 
 By default, the query results are cached in memory allowing for rapid iteration of result row content.
@@ -188,6 +194,7 @@ defer rows.Close()
 
 // Use rows result as normal.
 ```
+
 If you want to disable paging on the same context all together, you can simply set the row
 limit to 0 (the default).
 
@@ -241,41 +248,47 @@ opts := &sql.TxOptions{
 // Begin the transaction.
 tx, err := connDB.BeginTx(ctx, opts)
 ```
+
 ```Go
 // You can either commit it.
 err = tx.Commit()
 ```
+
 ```Go
 // Or roll it back.
 err = tx.Rollback()
 ```
+
 The following transaction isolation levels are supported:
 
- * sql.LevelReadUncommitted <sup><b>&#8224;</b></sup>
- * sql.LevelReadCommitted
- * sql.LevelSerializable
- * sql.LevelRepeatableRead <sup><b>&#8224;</b></sup>
- * sql.LevelDefault
+* sql.LevelReadUncommitted <sup><b>&#8224;</b></sup>
+* sql.LevelReadCommitted
+* sql.LevelSerializable
+* sql.LevelRepeatableRead <sup><b>&#8224;</b></sup>
+* sql.LevelDefault
 
  The following transaction isolation levels are unsupported:
 
- * sql.LevelSnapshot
- * sql.LevelLinearizable
+* sql.LevelSnapshot
+* sql.LevelLinearizable
 
  <b>&#8224;</b> Although Vertica supports the grammars for these transaction isolation levels, they are internally promoted to stronger isolation levels.
 
 ## COPY modes Supported
 
 ### COPY FROM STDIN
+
 vertica-sql-go supports copying from stdin. This allows you to write a command-line tool that accepts stdin as an
 input and passes it to Vertica for processing. An example:
 
 ```go
 _, err = connDB.ExecContext(ctx, "COPY stdin_data FROM STDIN DELIMITER ','")
 ```
+
 This will process input from stdin until an EOF is reached.
 
 ### COPY FROM STDIN with alternate stream
+
 In your code, you may also supply a different io.Reader object (such as *File) from which to supply your data.
 Simply create a new VerticaContext, set the copy input stream, and provide this context to the execute call.
 An example:
@@ -362,7 +375,6 @@ func main() {
     os.Exit(0)
 }
 ```
-
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/vertica/vertica-sql-go
+
+go 1.13

--- a/stmt.go
+++ b/stmt.go
@@ -147,7 +147,6 @@ func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
 	namedArgs := make([]driver.NamedValue, len(args))
 	for idx, arg := range args {
 		namedArgs[idx] = driver.NamedValue{
-			Name:    "",
 			Ordinal: idx,
 			Value:   arg,
 		}
@@ -263,7 +262,7 @@ func (s *stmt) copySTDIN(ctx context.Context) {
 			break
 		}
 		if err != nil {
-			s.conn.sendMessage(&msgs.FELoadFailMsg{err.Error()})
+			s.conn.sendMessage(&msgs.FELoadFailMsg{Message: err.Error()})
 			break
 		}
 		s.conn.sendMessage(&msgs.FELoadDataMsg{Data: block, UsedBytes: bytesRead})
@@ -289,7 +288,7 @@ func (s *stmt) interpolate(args []driver.NamedValue) (string, error) {
 		case int64, float64:
 			replaceStr = fmt.Sprintf("%v", v)
 		case string:
-			replaceStr = fmt.Sprintf("'%s'", v)
+			replaceStr = fmt.Sprintf("'%s'", strings.ReplaceAll(v, "'", "''"))
 		case bool:
 			if v {
 				replaceStr = "true"
@@ -308,7 +307,7 @@ func (s *stmt) interpolate(args []driver.NamedValue) (string, error) {
 			replaceStr = "?unknown_type?"
 		}
 
-		result = strings.Replace(result, "?", replaceStr, -1)
+		result = strings.Replace(result, "?", replaceStr, 1)
 	}
 
 	return result, nil

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -1,0 +1,74 @@
+package vertigo
+
+// Copyright (c) 2020 Micro Focus or one of its affiliates.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//    http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import (
+	"database/sql/driver"
+	"testing"
+)
+
+func testStatement(command string) *stmt {
+	return &stmt{
+		command:      command,
+		preparedName: "TestCommand",
+		parseState:   parseStateUnparsed,
+	}
+}
+
+func TestInterpolate(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		command  string
+		expected string
+		args     []driver.NamedValue
+	}{
+		{
+			name:     "no parameters",
+			command:  "select * from something",
+			expected: "select * from something",
+			args:     []driver.NamedValue{},
+		},
+		{
+			name:     "simple string",
+			command:  "select * from something where value = ?",
+			expected: "select * from something where value = 'taco'",
+			args:     []driver.NamedValue{{Value: "taco"}},
+		},
+		{
+			name:     "multiple values",
+			command:  "select * from something where value = ? and otherVal = ?",
+			expected: "select * from something where value = 'taco' and otherVal = 15.5",
+			args:     []driver.NamedValue{{Value: "taco"}, {Value: 15.5}},
+		},
+		{
+			name:     "strings with quotes",
+			command:  "select * from something where value = ?",
+			expected: "select * from something where value = 'it''s other''s'",
+			args:     []driver.NamedValue{{Value: "it's other's"}},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt := testStatement(tc.command)
+			result, err := stmt.interpolate(tc.args)
+			if result != tc.expected {
+				t.Errorf("Expected query to be %s but got %s", tc.command, result)
+			}
+			if err != nil {
+				t.Errorf("Received error from interpolate: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fix string interpolation containing single quotes

Fix interpolation with multiple parameters

Fix a couple of linter issues in readme and stmt.go

I see there are also tests in driver_test.go but those seem to actually hit a database and I don't have a development database set up to run against.