### PR TITLE
Introduce support for named parameters in query using @name syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ With client interpolation enabled, the client library will create a new query st
 
 With client interpolation disabled (default), the client library will use the full server-side parse(), describe(), bind(), execute() cycle.
 
+#### Named Arguments
+
+```Go
+rows, err := connDB.QueryContext(ctx, "SELECT name FROM MyTable WHERE id=@id and something=@example", sql.Named("id", 21), sql.Named("example", "hello"))
+```
+
+Named arguments are emulated by the driver. They will be converted to positional arguments by the driver and the named arguments given later will be slotted
+into the required positions. This still allows server side prepared statements as `@id` and `@example` above will be replaced by `?` before being sent. If
+you use named arguments, all the arguments must be named. Do not mix positional and named together.
+
 ### Reading query result rows
 
 As outlined in the GoLang specs, reading the results of a query is done via a loop, bounded by a .next() iterator.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ rows, err := connDB.QueryContext(ctx, "SELECT name FROM MyTable WHERE id=@id and
 
 Named arguments are emulated by the driver. They will be converted to positional arguments by the driver and the named arguments given later will be slotted
 into the required positions. This still allows server side prepared statements as `@id` and `@example` above will be replaced by `?` before being sent. If
-you use named arguments, all the arguments must be named. Do not mix positional and named together.
+you use named arguments, all the arguments must be named. Do not mix positional and named together. All named arguments are normalized to upper case which means
+`@param`, `@PaRaM`, and `@PARAM` are treated as equivalent.
 
 ### Reading query result rows
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -196,6 +196,32 @@ func TestBasicQuery(t *testing.T) {
 
 }
 
+func TestBasicNamedArgs(t *testing.T) {
+	connDB := openConnection(t)
+	defer closeConnection(t, connDB)
+	rows, err := connDB.QueryContext(ctx, "SELECT DISTINCT(keyword) FROM v_catalog.standard_keywords WHERE reserved=@type LIMIT 10", sql.Named("type", "R"))
+	assertNoErr(t, err)
+	defer rows.Close()
+	for rows.Next() {
+		var keyword string
+		assertNoErr(t, rows.Scan(&keyword))
+	}
+}
+
+func TestPreparedNamedArgs(t *testing.T) {
+	connDB := openConnection(t)
+	defer closeConnection(t, connDB)
+	stmt, err := connDB.PrepareContext(ctx, "SELECT DISTINCT(keyword) FROM v_catalog.standard_keywords WHERE reserved=@type LIMIT 10")
+	assertNoErr(t, err)
+	rows, err := stmt.QueryContext(ctx, sql.Named("type", "R"))
+	assertNoErr(t, err)
+	defer rows.Close()
+	for rows.Next() {
+		var keyword string
+		assertNoErr(t, rows.Scan(&keyword))
+	}
+}
+
 func TestBasicExec(t *testing.T) {
 	connDB := openConnection(t, "test_basic_exec_pre")
 	defer closeConnection(t, connDB, "test_basic_exec_post")

--- a/parse/queryLex.go
+++ b/parse/queryLex.go
@@ -55,7 +55,7 @@ type Lexer struct {
 	output       strings.Builder
 }
 
-// LexOption is a function that sets a prefernce on the lexer
+// LexOption is a function that sets a preference on the lexer
 type LexOption func(*Lexer)
 
 // WithPositionalSubstitution sets the optional positional substitution callback
@@ -202,7 +202,7 @@ func lexNamedParam(l *Lexer) stateFunc {
 	l.start = l.pos
 	// advance through the name
 	l.consumeToSpace()
-	if !l.done() {
+	if !l.done() || strings.HasSuffix(l.input[l.start:l.pos], "\n") {
 		l.backup() // move back before the whitespace character
 	}
 	l.onNamed(l.input[l.start:l.pos])

--- a/parse/queryLex.go
+++ b/parse/queryLex.go
@@ -1,0 +1,223 @@
+package parse
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Copyright (c) 2020 Micro Focus or one of its affiliates.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//    http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// SubstitutePosParam is called by the lexer when a '?' rune is encountered
+// outside a string. The return value is substituted for the placeholder.
+// This can be used to emulate server side binding but should be done with
+// extreme caution due to the risk of SQL injection.
+type SubstitutePosParam func() string
+
+// by default leave the positional arguments alone
+func defaultPosSubstitution() string {
+	return "?"
+}
+
+// OnNamedParam is called when a value such as @queryParam is encountered.
+// This can be used to associate a placeholder in the SQL to an index. The
+// placeholders are encountered in the order they appear in the string.
+type OnNamedParam func(name string)
+
+// by default just ignore the named parameters
+func defaultNamedCallback(name string) {
+
+}
+
+const eof = -1
+
+// Lexer loosely breaks a SQL query down into chunks that
+// the Vertica package cares about, offering opportunities for substitution.
+type Lexer struct {
+	input        string
+	pos          int
+	start        int
+	width        int
+	onNamed      OnNamedParam
+	onPositional SubstitutePosParam
+	output       strings.Builder
+}
+
+// LexOption is a function that sets a prefernce on the lexer
+type LexOption func(*Lexer)
+
+// WithPositionalSubstitution sets the optional positional substitution callback
+func WithPositionalSubstitution(cb SubstitutePosParam) LexOption {
+	return func(l *Lexer) {
+		l.onPositional = cb
+	}
+}
+
+// WithNamedCallback sets the optional named parameter callback
+func WithNamedCallback(cb OnNamedParam) LexOption {
+	return func(l *Lexer) {
+		l.onNamed = cb
+	}
+}
+
+// LexOptions converts an aritrary number of options into one function
+// for easier handling
+func LexOptions(opts ...LexOption) LexOption {
+	return func(l *Lexer) {
+		for _, opt := range opts {
+			opt(l)
+		}
+	}
+}
+
+func defaultOptions() LexOption {
+	return func(l *Lexer) {
+		l.onNamed = defaultNamedCallback
+		l.onPositional = defaultPosSubstitution
+	}
+}
+
+// Lex through a given query, optionally substituting some values in the string
+func Lex(query string, options ...LexOption) string {
+	l := &Lexer{
+		input:  query,
+		output: strings.Builder{},
+	}
+	LexOptions(defaultOptions(), LexOptions(options...))(l)
+	l.run()
+	return l.output.String()
+}
+
+func (l *Lexer) run() {
+	for state := lexQuery; state != nil; {
+		state = state(l)
+	}
+}
+func (l *Lexer) skipUntil(val rune) {
+	for {
+		next := l.next()
+		if next == val || next == eof {
+			return
+		}
+	}
+}
+
+func (l *Lexer) consumeToSpace() {
+	for !l.done() && !unicode.IsSpace(l.next()) {
+	}
+}
+
+func (l *Lexer) next() rune {
+	if l.done() {
+		l.width = 0
+		return eof
+	}
+	r, w := utf8.DecodeRuneInString(l.input[l.pos:])
+	l.width = w
+	l.pos += l.width
+	return r
+}
+
+func (l *Lexer) backup() {
+	l.pos -= l.width
+}
+
+func (l *Lexer) current() rune {
+	r, _ := utf8.DecodeRuneInString(l.input[l.pos:])
+	return r
+}
+
+func (l *Lexer) peek() rune {
+	r := l.next()
+	l.backup()
+	return r
+}
+
+func (l *Lexer) done() bool {
+	return l.pos >= len(l.input)
+}
+
+func (l *Lexer) writeChunk() {
+	l.output.WriteString(l.input[l.start:l.pos])
+	l.start = l.pos
+}
+
+type stateFunc func(l *Lexer) stateFunc
+
+func lexQuery(l *Lexer) stateFunc {
+	for r := l.current(); r != eof; r = l.next() {
+		if r == '-' && l.peek() == '-' {
+			return lexComment
+		}
+
+		if r == '\'' {
+			return lexString
+		}
+
+		if r == '@' {
+			return lexNamedParam
+		}
+
+		if r == '?' {
+			return lexPositional
+		}
+	}
+	l.writeChunk()
+	return nil
+}
+
+func lexComment(l *Lexer) stateFunc {
+	l.skipUntil('\n')
+	l.writeChunk()
+	return lexQuery
+}
+
+// lexString assumes we are starting inside the string and goes to the next ' rune
+// if it was an escaped quote like 'isn''t' lexQuery will drop us right back here to finish
+func lexString(l *Lexer) stateFunc {
+	l.skipUntil('\'')
+	l.writeChunk()
+	return lexQuery
+}
+
+// lexNamedParam replaces named params like @named with a ? while calling out to a consumer
+// with the encountered name, minus the @ prefix
+func lexNamedParam(l *Lexer) stateFunc {
+	// write everything before the @
+	l.backup()
+	l.writeChunk()
+	l.next()
+	l.start = l.pos
+	// advance through the name
+	l.consumeToSpace()
+	if !l.done() {
+		l.backup() // move back before the whitespace character
+	}
+	l.onNamed(l.input[l.start:l.pos])
+	l.start = l.pos
+	l.output.WriteRune('?')
+	return lexQuery
+}
+
+// lexPositional calls out to the consumer for something to replace the ? with. By default they will
+// be left in place
+func lexPositional(l *Lexer) stateFunc {
+	l.backup()
+	l.writeChunk()
+	l.output.WriteString(l.onPositional())
+	l.next()
+	l.start = l.pos
+	return lexQuery
+}

--- a/parse/queryLex.go
+++ b/parse/queryLex.go
@@ -205,7 +205,7 @@ func lexNamedParam(l *Lexer) stateFunc {
 	if !l.done() || strings.HasSuffix(l.input[l.start:l.pos], "\n") {
 		l.backup() // move back before the whitespace character
 	}
-	l.onNamed(l.input[l.start:l.pos])
+	l.onNamed(strings.ToUpper(l.input[l.start:l.pos]))
 	l.start = l.pos
 	l.output.WriteRune('?')
 	return lexQuery

--- a/parse/queryLex_test.go
+++ b/parse/queryLex_test.go
@@ -1,0 +1,165 @@
+package parse
+
+// Copyright (c) 2020 Micro Focus or one of its affiliates.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//    http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import "testing"
+
+func TestSkipUntil(t *testing.T) {
+	lexer := Lexer{input: "select * from a where test = 'b'"}
+	lexer.skipUntil('\'')
+	if cur := lexer.current(); cur != 'b' {
+		t.Errorf("Expected to be on b but got %q", cur)
+	}
+	lexer.skipUntil('\'')
+	if lexer.pos != len(lexer.input) {
+		t.Errorf("Should be on %d, on %d with %q", len(lexer.input), lexer.pos, lexer.current())
+	}
+}
+
+type nameCapture struct {
+	names []string
+}
+
+func (n *nameCapture) reset() {
+	n.names = n.names[:0]
+}
+
+func (n *nameCapture) store(name string) {
+	n.names = append(n.names, name)
+}
+
+func TestLexNamed(t *testing.T) {
+	var testCases = []struct {
+		name           string
+		query          string
+		expectedNamed  []string
+		expectedOutput string
+	}{
+		{
+			name:           "empty string",
+			query:          "",
+			expectedNamed:  []string{},
+			expectedOutput: "",
+		},
+		{
+			name:           "simple query, no params",
+			query:          "select * from whatever where a = 'test'",
+			expectedNamed:  []string{},
+			expectedOutput: "select * from whatever where a = 'test'",
+		},
+		{
+			name:           "with some named parameters",
+			query:          "select * from whatever where a = @first and b = @second and c = '@fooledYou'",
+			expectedNamed:  []string{"first", "second"},
+			expectedOutput: "select * from whatever where a = ? and b = ? and c = '@fooledYou'",
+		},
+		{
+			name:           "with a pre-escaped string",
+			query:          "select * from whatever where a = @first and b = 'isn''t",
+			expectedNamed:  []string{"first"},
+			expectedOutput: "select * from whatever where a = ? and b = 'isn''t",
+		},
+		{
+			name:           "do not choke on malformed query string",
+			query:          "select * from whatever where a = @first and b = 'isn'''t",
+			expectedNamed:  []string{"first"},
+			expectedOutput: "select * from whatever where a = ? and b = 'isn'''t",
+		},
+		{
+			name: "with a comment",
+			query: `select --some select stuff
+			* from whatever where a = @param`,
+			expectedNamed: []string{"param"},
+			expectedOutput: `select --some select stuff
+			* from whatever where a = ?`,
+		},
+		{
+			name: "named params on line endings",
+			query: `select
+			* from table
+			where
+			a = @param1
+			and b = @param2`,
+			expectedNamed: []string{"param1", "param2"},
+			expectedOutput: `select
+			* from table
+			where
+			a = ?
+			and b = ?`,
+		},
+	}
+	var encounteredNames nameCapture
+	for _, tc := range testCases {
+		encounteredNames.reset()
+		t.Run(tc.name, func(t *testing.T) {
+			result := Lex(tc.query, WithNamedCallback(encounteredNames.store))
+			if result != tc.expectedOutput {
+				t.Errorf("Expected query:\n%s\nGot:\n%s", tc.expectedOutput, result)
+			}
+			if len(encounteredNames.names) != len(tc.expectedNamed) {
+				t.Errorf("Encountered %d named params, expected %d", len(encounteredNames.names), len(tc.expectedNamed))
+			}
+			for i := range encounteredNames.names {
+				if encounteredNames.names[i] != tc.expectedNamed[i] {
+					t.Errorf("Expected name at %d to be %s but got %s", i, tc.expectedNamed[i], encounteredNames.names[i])
+				}
+			}
+		})
+	}
+}
+
+func swapPos() string {
+	return "'replaced'"
+}
+func TestLexPositional(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		query    string
+		expected string
+	}{
+		{
+			name:     "single parameter",
+			query:    "select * from table where a = ? and b = 2",
+			expected: "select * from table where a = 'replaced' and b = 2",
+		},
+		{
+			name:     "end on parameter",
+			query:    "select * from table where a = ?",
+			expected: "select * from table where a = 'replaced'",
+		},
+		{
+			name:     "? hidden in a string",
+			query:    "select * from table where a = ? and b = '?fooledYou'",
+			expected: "select * from table where a = 'replaced' and b = '?fooledYou'",
+		},
+		{
+			name: "? hidden in a comment",
+			query: `select
+			* from -- maybe broken?
+			where a = ?`,
+			expected: `select
+			* from -- maybe broken?
+			where a = 'replaced'`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := Lex(tc.query, WithPositionalSubstitution(swapPos))
+			if result != tc.expected {
+				t.Errorf("Expected query:\n%s\nGot:\n%s", tc.expected, result)
+			}
+		})
+	}
+}

--- a/parse/queryLex_test.go
+++ b/parse/queryLex_test.go
@@ -62,26 +62,32 @@ func TestLexNamed(t *testing.T) {
 		{
 			name:           "with some named parameters",
 			query:          "select * from whatever where a = @first and b = @second and c = '@fooledYou'",
-			expectedNamed:  []string{"first", "second"},
+			expectedNamed:  []string{"FIRST", "SECOND"},
 			expectedOutput: "select * from whatever where a = ? and b = ? and c = '@fooledYou'",
+		},
+		{
+			name:           "with mixed case named parameters",
+			query:          "select * from whatever where a = @first and b = @fIrSt",
+			expectedNamed:  []string{"FIRST", "FIRST"},
+			expectedOutput: "select * from whatever where a = ? and b = ?",
 		},
 		{
 			name:           "with a pre-escaped string",
 			query:          "select * from whatever where a = @first and b = 'isn''t",
-			expectedNamed:  []string{"first"},
+			expectedNamed:  []string{"FIRST"},
 			expectedOutput: "select * from whatever where a = ? and b = 'isn''t",
 		},
 		{
 			name:           "do not choke on malformed query string",
 			query:          "select * from whatever where a = @first and b = 'isn'''t",
-			expectedNamed:  []string{"first"},
+			expectedNamed:  []string{"FIRST"},
 			expectedOutput: "select * from whatever where a = ? and b = 'isn'''t",
 		},
 		{
 			name: "with a comment",
 			query: `select --some select stuff
 			* from whatever where a = @param`,
-			expectedNamed: []string{"param"},
+			expectedNamed: []string{"PARAM"},
 			expectedOutput: `select --some select stuff
 			* from whatever where a = ?`,
 		},
@@ -92,7 +98,7 @@ func TestLexNamed(t *testing.T) {
 			where
 			a = @param1
 			and b = @param2`,
-			expectedNamed: []string{"param1", "param2"},
+			expectedNamed: []string{"PARAM1", "PARAM2"},
 			expectedOutput: `select
 			* from table
 			where
@@ -106,7 +112,7 @@ func TestLexNamed(t *testing.T) {
 			where
 			a = @param1
 `,
-			expectedNamed: []string{"param1"},
+			expectedNamed: []string{"PARAM1"},
 			expectedOutput: `select
 			* from table
 			where

--- a/parse/queryLex_test.go
+++ b/parse/queryLex_test.go
@@ -99,6 +99,20 @@ func TestLexNamed(t *testing.T) {
 			a = ?
 			and b = ?`,
 		},
+		{
+			name: "named params with ending newline",
+			query: `select
+			* from table
+			where
+			a = @param1
+`,
+			expectedNamed: []string{"param1"},
+			expectedOutput: `select
+			* from table
+			where
+			a = ?
+`,
+		},
 	}
 	var encounteredNames nameCapture
 	for _, tc := range testCases {

--- a/stmt.go
+++ b/stmt.go
@@ -173,14 +173,14 @@ func (s *stmt) injectNamedArgs(args []driver.NamedValue) ([]driver.NamedValue, e
 	symbols := make(map[string]driver.NamedValue, len(args))
 	for _, arg := range args {
 		if len(arg.Name) > 0 {
-			symbols[arg.Name] = arg
+			symbols[strings.ToUpper(arg.Name)] = arg
 			continue
 		}
 		namedVal, ok := arg.Value.(driver.NamedValue)
 		if !ok || len(namedVal.Name) == 0 {
 			return nil, errors.New("all parameters must have names when using named parameters")
 		}
-		symbols[namedVal.Name] = namedVal
+		symbols[strings.ToUpper(namedVal.Name)] = namedVal
 	}
 	realArgs := make([]driver.NamedValue, len(s.namedArgPos))
 	for pos, name := range s.namedArgPos {

--- a/stmt.go
+++ b/stmt.go
@@ -35,6 +35,7 @@ package vertigo
 import (
 	"context"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -47,6 +48,7 @@ import (
 	"github.com/vertica/vertica-sql-go/common"
 	"github.com/vertica/vertica-sql-go/logger"
 	"github.com/vertica/vertica-sql-go/msgs"
+	"github.com/vertica/vertica-sql-go/parse"
 )
 
 var (
@@ -66,6 +68,7 @@ type stmt struct {
 	command      string
 	preparedName string
 	parseState   parseState
+	namedArgPos  []string
 	paramTypes   []common.ParameterType
 	lastRowDesc  *msgs.BERowDescMsg
 }
@@ -76,12 +79,17 @@ func newStmt(connection *connection, command string) (*stmt, error) {
 		return nil, fmt.Errorf("cannot create an empty statement")
 	}
 
-	return &stmt{
+	s := &stmt{
 		conn:         connection,
-		command:      command,
 		preparedName: fmt.Sprintf("S%d%d%d", os.Getpid(), time.Now().Unix(), rand.Int31()),
 		parseState:   parseStateUnparsed,
-	}, nil
+	}
+	s.command = parse.Lex(command, parse.WithNamedCallback(s.pushNamed))
+	return s, nil
+}
+
+func (s *stmt) pushNamed(name string) {
+	s.namedArgPos = append(s.namedArgPos, name)
 }
 
 // Close closes this statement.
@@ -127,32 +135,55 @@ func (s *stmt) NumInput() int {
 	return strings.Count(s.command, "?")
 }
 
-// Exec docs
-func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
-
+// convertToNamed takes an argument list of Value that come from the older Exec/Query functions
+// and converts them to NamedValue to be forwarded to their Context equivalents.
+func (s *stmt) convertToNamed(args []driver.Value) []driver.NamedValue {
 	namedArgs := make([]driver.NamedValue, len(args))
 	for idx, arg := range args {
 		namedArgs[idx] = driver.NamedValue{
-			Name:    "",
 			Ordinal: idx,
 			Value:   arg,
 		}
 	}
-	return s.ExecContext(context.Background(), namedArgs)
+	return namedArgs
+}
+
+// injectNamedArgs takes a list of arguments, builds a symbol table of name => arg and then
+// fills a list of positional arguments based on the names from the args parameter
+// This will return an error if any of the given args lack a name
+func (s *stmt) injectNamedArgs(args []driver.NamedValue) ([]driver.NamedValue, error) {
+	if len(s.namedArgPos) == 0 {
+		return args, nil
+	}
+	symbols := make(map[string]driver.NamedValue, len(args))
+	for _, arg := range args {
+		if len(arg.Name) > 0 {
+			symbols[arg.Name] = arg
+			continue
+		}
+		namedVal, ok := arg.Value.(driver.NamedValue)
+		if !ok || len(namedVal.Name) == 0 {
+			return nil, errors.New("all parameters must have names when using named parameters")
+		}
+		symbols[namedVal.Name] = namedVal
+	}
+	realArgs := make([]driver.NamedValue, len(s.namedArgPos))
+	for pos, name := range s.namedArgPos {
+		realArgs[pos] = symbols[name]
+		realArgs[pos].Ordinal = pos
+	}
+	return realArgs, nil
+}
+
+// Exec docs
+func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
+	return s.ExecContext(context.Background(), s.convertToNamed(args))
 }
 
 // Query docs
 func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
 	stmtLogger.Debug("stmt.Query(): %s\n", s.command)
-
-	namedArgs := make([]driver.NamedValue, len(args))
-	for idx, arg := range args {
-		namedArgs[idx] = driver.NamedValue{
-			Ordinal: idx,
-			Value:   arg,
-		}
-	}
-	return s.QueryContext(context.Background(), namedArgs)
+	return s.QueryContext(context.Background(), s.convertToNamed(args))
 }
 
 // ExecContext docs
@@ -182,12 +213,17 @@ func (s *stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driv
 }
 
 // QueryContext docs
-func (s *stmt) QueryContextRaw(ctx context.Context, args []driver.NamedValue) (*rows, error) {
+func (s *stmt) QueryContextRaw(ctx context.Context, baseArgs []driver.NamedValue) (*rows, error) {
 	stmtLogger.Debug("stmt.QueryContextRaw(): %s", s.command)
 
 	var cmd string
 	var err error
 	var portalName string
+
+	args, err := s.injectNamedArgs(baseArgs)
+	if err != nil {
+		return newEmptyRows(), err
+	}
 
 	s.conn.lockSessionMutex()
 	defer s.conn.unlockSessionMutex()
@@ -291,6 +327,33 @@ func (s *stmt) cleanQuotes(val string) string {
 	return cleaned.String()
 }
 
+func (s *stmt) formatArg(arg driver.NamedValue) string {
+	var replaceStr string
+	switch v := arg.Value.(type) {
+	case int64, float64:
+		replaceStr = fmt.Sprintf("%v", v)
+	case string:
+		replaceStr = fmt.Sprintf("'%s'", s.cleanQuotes(v))
+	case bool:
+		if v {
+			replaceStr = "true"
+		} else {
+			replaceStr = "false"
+		}
+	case time.Time:
+		replaceStr = fmt.Sprintf("%02d-%02d-%02d %02d:%02d:%02d",
+			v.Year(),
+			v.Month(),
+			v.Day(),
+			v.Hour(),
+			v.Minute(),
+			v.Second())
+	default:
+		replaceStr = "?unknown_type?"
+	}
+	return replaceStr
+}
+
 func (s *stmt) interpolate(args []driver.NamedValue) (string, error) {
 
 	numArgs := s.NumInput()
@@ -299,38 +362,14 @@ func (s *stmt) interpolate(args []driver.NamedValue) (string, error) {
 		return s.command, nil
 	}
 
-	result := s.command
-
-	var replaceStr string
-
-	for _, arg := range args {
-
-		switch v := arg.Value.(type) {
-		case int64, float64:
-			replaceStr = fmt.Sprintf("%v", v)
-		case string:
-			replaceStr = fmt.Sprintf("'%s'", s.cleanQuotes(v))
-		case bool:
-			if v {
-				replaceStr = "true"
-			} else {
-				replaceStr = "false"
-			}
-		case time.Time:
-			replaceStr = fmt.Sprintf("%02d-%02d-%02d %02d:%02d:%02d",
-				v.Year(),
-				v.Month(),
-				v.Day(),
-				v.Hour(),
-				v.Minute(),
-				v.Second())
-		default:
-			replaceStr = "?unknown_type?"
-		}
-
-		result = strings.Replace(result, "?", replaceStr, 1)
+	curArg := 0
+	argSwapper := func() string {
+		arg := s.formatArg(args[curArg])
+		curArg++
+		return arg
 	}
 
+	result := parse.Lex(s.command, parse.WithPositionalSubstitution(argSwapper))
 	return result, nil
 }
 

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -177,3 +177,47 @@ func TestInjectNamedArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestNumInput(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		query    string
+		expected int
+	}{
+		{
+			name:     "basic positional",
+			query:    "select * from table where a = ?",
+			expected: 1,
+		},
+		{
+			name:     "basic named",
+			query:    "select * from table where a = @name",
+			expected: 1,
+		},
+		{
+			name:     "reused named",
+			query:    "select * from table where a = @name and b = @name and c = @id",
+			expected: 2,
+		},
+		{
+			name: "positional character in comment",
+			query: `select * --test?
+			from table where a = 1`,
+			expected: 0,
+		},
+		{
+			name:     "positional character in string",
+			query:    "select * from test where a = 'test?'",
+			expected: 0,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt, _ := newStmt(nil, tc.query)
+			result := stmt.NumInput()
+			if result != tc.expected {
+				t.Errorf("Expected %d query inputs, got %d", tc.expected, result)
+			}
+		})
+	}
+}

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -20,11 +20,8 @@ import (
 )
 
 func testStatement(command string) *stmt {
-	return &stmt{
-		command:      command,
-		preparedName: "TestCommand",
-		parseState:   parseStateUnparsed,
-	}
+	stmt, _ := newStmt(nil, command)
+	return stmt
 }
 
 func TestInterpolate(t *testing.T) {


### PR DESCRIPTION
Use a lexer to handle parameters
Fixes #54 by handling comments and strings.
Closes #60 by adding support for named parameters