### PR TITLE
Rollback severity seems to end the connection

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -71,6 +71,7 @@ type connection struct {
 	scratch          [512]byte
 	sessionID        string
 	serverTZOffset   string
+	dead             bool // used if a ROLLBACK severity error is encountered
 	sessMutex        sync.Mutex
 }
 
@@ -153,6 +154,9 @@ func (v *connection) Ping(ctx context.Context) error {
 // ResetSession implements the SessionResetter interface for connection. This allows the sql
 // package to evaluate the connection state when managing the connection pool.
 func (v *connection) ResetSession(ctx context.Context) error {
+	if v.dead {
+		return driver.ErrBadConn
+	}
 	return v.Ping(ctx)
 }
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -780,6 +780,30 @@ func TestEnableResultCache(t *testing.T) {
 	testEnableResultCachePageSized(t, connDB, vCtx, 0)
 }
 
+func TestConcurrentStatementQuery(t *testing.T) {
+	connDB := openConnection(t, "test_stmt_ordering_threads_pre")
+	defer closeConnection(t, connDB, "test_stmt_ordering_threads_post")
+	stmt, err := connDB.PrepareContext(ctx, "SELECT a FROM stmt_thread_test")
+	assertNoErr(t, err)
+	wg := new(sync.WaitGroup)
+	wg.Add(3)
+	for i := 0; i < 3; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := stmt.QueryContext(ctx)
+			assertNoErr(t, err)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestInvalidDDLStatement(t *testing.T) {
+	connDB := openConnection(t)
+	defer closeConnection(t, connDB)
+	_, err := connDB.Exec("DROP VIEW DOESNOTEXISTVIEW")
+	assertErr(t, err, "does not exist")
+}
+
 var verticaUserName = flag.String("user", "dbadmin", "the user name to connect to Vertica")
 var verticaPassword = flag.String("password", os.Getenv("VERTICA_TEST_PASSWORD"), "Vertica password for this user")
 var verticaHostPort = flag.String("locator", "localhost:5433", "Vertica's host and port")

--- a/msgs/beerrormsg.go
+++ b/msgs/beerrormsg.go
@@ -46,7 +46,7 @@ type BEErrorMsg struct {
 	Routine  string
 }
 
-// InitFromMsgBody docs
+// CreateFromMsgBody docs
 func (b *BEErrorMsg) CreateFromMsgBody(buf *msgBuffer) (BackEndMsg, error) {
 
 	res := &BEErrorMsg{}

--- a/msgs/msg.go
+++ b/msgs/msg.go
@@ -36,25 +36,30 @@ import (
 	"fmt"
 )
 
+// CmdTargetType describes the target of a command
 type CmdTargetType byte
 
-var (
+// Possible command targets
+const (
 	CmdTargetTypePortal    CmdTargetType = 'P'
 	CmdTargetTypeStatement CmdTargetType = 'S'
 )
 
-// FrontEndMsg docs
+// FrontEndMsg is sent from the adapter to the database
 type FrontEndMsg interface {
 	Flatten() ([]byte, byte)
 	String() string
 }
 
-// BackEndMsg docs
+// BackEndMsg is received from the database
 type BackEndMsg interface {
 	CreateFromMsgBody(*msgBuffer) (BackEndMsg, error)
 	String() string
 }
 
+// backEndMsgTypeMap is a global map of message descriptor bytes to instances
+// of that message. The instances are not used directly, but instead are used to
+// construct new values of that message type. This is populated on init.
 var backEndMsgTypeMap = make(map[byte]BackEndMsg)
 
 func registerBackEndMsgType(msgType byte, bem BackEndMsg) {

--- a/stmt.go
+++ b/stmt.go
@@ -105,6 +105,8 @@ func (s *stmt) Close() error {
 		return nil
 	}
 	if s.rolledBack {
+		s.parseState = parseStateUnparsed
+		s.conn.dead = true
 		return nil
 	}
 	closeMsg := &msgs.FECloseMsg{TargetType: msgs.CmdTargetTypeStatement, TargetName: s.preparedName}


### PR DESCRIPTION
Check for ROLLBACK severity and
guard against it in Close

Fixes #61
Fixes #48

Most of the changes in `Close` are white space, I swapped the if check to a if-return guard and then un-indented the body of it.