### PR TITLE
Implement ping and test connection state

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -786,6 +786,7 @@ func TestConnectionClosure(t *testing.T) {
 	const userQuery = "select 1 as test"
 
 	userDB, _ := sql.Open("vertica", otherConnectString)
+	defer userDB.Close()
 	rows, err := userDB.Query(userQuery)
 	assertNoErr(t, err)
 	rows.Close()

--- a/driver_test.go
+++ b/driver_test.go
@@ -792,7 +792,9 @@ func TestConnectionClosure(t *testing.T) {
 	rows.Close()
 	adminDB.Query("select close_user_sessions('TestGuy')")
 	_, err = userDB.Query(userQuery)
-	assertErr(t, err, "EOF")
+	if err == nil {
+		t.Error("Should have seen an error on second query")
+	}
 	rows, err = userDB.Query(userQuery)
 	assertNoErr(t, err)
 	rows.Close()

--- a/driver_test.go
+++ b/driver_test.go
@@ -791,12 +791,13 @@ func TestConnectionClosure(t *testing.T) {
 	assertNoErr(t, err)
 	rows.Close()
 	adminDB.Query("select close_user_sessions('TestGuy')")
-	_, err = userDB.Query(userQuery)
+	rows, err = userDB.Query(userQuery)
+	// Depending on Go version this second query may or may not error
 	if err == nil {
-		t.Error("Should have seen an error on second query")
+		rows.Close()
 	}
 	rows, err = userDB.Query(userQuery)
-	assertNoErr(t, err)
+	assertNoErr(t, err) // Should definitely have a working connection again here
 	rows.Close()
 }
 

--- a/resources/tests/driver_test/test_connection_closed_post.sql
+++ b/resources/tests/driver_test/test_connection_closed_post.sql
@@ -1,0 +1,1 @@
+DROP USER IF EXISTS TestGuy

--- a/resources/tests/driver_test/test_connection_closed_pre.sql
+++ b/resources/tests/driver_test/test_connection_closed_pre.sql
@@ -1,0 +1,5 @@
+-- Remove user if needed.
+DROP USER IF EXISTS TestGuy;
+
+CREATE USER TestGuy IDENTIFIED BY 'TestGuyPass';
+GRANT USAGE ON SCHEMA PUBLIC to TestGuy;


### PR DESCRIPTION
Fixes #51

Right now the documentation [here](https://www.vertica.com/blog/the-vertica-sql-driver-for-go/) is a little misleading because the driver does not actually implement `Pinger` and so `Ping` will never return an error. Implementing Ping allows us to cleanly implement `SessionResetter` to the sql package can check the connection state.

Try running [this gist](https://gist.github.com/mlh758/265b5f5cfae08450cf04aec639033986) before and after this commit. You'll need to fix the `replace` directive in go.mod to match wherever you have your local copy of this repo. You'll also need a user `mike` identified by `pass` (or change the gist's connection string). Start the gist program, then run `select close_user_sessions('mike');` to kill the session. Before the patch, every tick will error with an EOF. After the patch _one_ tick will error with an EOF and future connections will work.

A next step would be internally implementing a retry.