### PR TITLE
Add benchmarks to aid in future development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin
 src/golang.org
 src/github.com
 *.code-workspace
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -395,6 +395,13 @@ Apache 2.0 License, please see `LICENSE` for details.
 
 Have a bug or an idea? Please see `CONTRIBUTING.md` for details.
 
+### Benchmarks
+
+You can run a benchmark and profile it with a command like:
+`go test -bench '^BenchmarkRowsWithLimit$' -benchmem -memprofile memprofile.out -cpuprofile profile.out -run=none`
+
+and then explore it with `go tool pprof`. The `-run` part excludes the tests for brevity.
+
 ## Acknowledgements
 
 We would like to thank the creators and contributors of the vertica-python library, and members of the Vertica team, for their help in understanding the wire protocol.

--- a/connection.go
+++ b/connection.go
@@ -356,7 +356,8 @@ func (v *connection) initializeSession() error {
 	}
 
 	// Peek into the results manually.
-	str := string(result.resultData[0].RowData[0])
+	colData := result.resultData[0].Columns()
+	str := string(colData.Chunk())
 
 	if len(str) < 23 {
 		return fmt.Errorf("can't get server timezone: %s", str)

--- a/msgs/bedatarowmsg_test.go
+++ b/msgs/bedatarowmsg_test.go
@@ -1,0 +1,47 @@
+package msgs
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func mockRow() []byte {
+	buf := bytes.NewBuffer(make([]byte, 0, 30))
+	binary.Write(buf, binary.BigEndian, int16(4))
+	binary.Write(buf, binary.BigEndian, int32(3))
+	binary.Write(buf, binary.BigEndian, []byte("123"))
+	binary.Write(buf, binary.BigEndian, int32(5))
+	binary.Write(buf, binary.BigEndian, []byte("hello"))
+	binary.Write(buf, binary.BigEndian, int32(1))
+	binary.Write(buf, binary.BigEndian, false)
+	binary.Write(buf, binary.BigEndian, int32(3))
+	binary.Write(buf, binary.BigEndian, []byte("456"))
+	return buf.Bytes()
+}
+
+func TestChunk(t *testing.T) {
+	msgBuf := NewMsgBufferFromBytes(mockRow())
+	var dMsg BEDataRowMsg
+	msgI, _ := dMsg.CreateFromMsgBody(msgBuf)
+	extractor := msgI.(*BEDataRowMsg).Columns()
+	if extractor.NumCols != 4 {
+		t.Errorf("Expected 4 columns but got %d", extractor.NumCols)
+	}
+	ch := extractor.Chunk()
+	if str := string(ch); str != "123" {
+		t.Errorf("Expected 123 got %s", str)
+	}
+	ch = extractor.Chunk()
+	if str := string(ch); str != "hello" {
+		t.Errorf("Expected hello got %s", str)
+	}
+	ch = extractor.Chunk()
+	if ch[0] != byte(0) {
+		t.Error("Expected false")
+	}
+	ch = extractor.Chunk()
+	if str := string(ch); str != "456" {
+		t.Errorf("Expected 456 got %s", str)
+	}
+}

--- a/rows.go
+++ b/rows.go
@@ -97,7 +97,7 @@ func (r *rows) reloadFromCache() bool {
 	r.readIndex = 0
 	indexCount := 0
 
-	for true {
+	for {
 		sizeBuf := r.scratch[:4]
 
 		if _, err := io.ReadFull(r.readWriteBuf, sizeBuf); err != nil {
@@ -107,9 +107,8 @@ func (r *rows) reloadFromCache() bool {
 				}
 				r.resultData = r.resultData[0:indexCount]
 				return true
-			} else {
-				return false
 			}
+			return false
 		}
 
 		rowDataSize := binary.LittleEndian.Uint32(sizeBuf)
@@ -156,9 +155,10 @@ func (r *rows) Next(dest []driver.Value) error {
 		}
 	}
 
-	thisRow := r.resultData[r.readIndex]
+	rowCols := r.resultData[r.readIndex].Columns()
 
-	for idx, colVal := range thisRow.RowData {
+	for idx := uint16(0); idx < rowCols.NumCols; idx++ {
+		colVal := rowCols.Chunk()
 		if colVal == nil {
 			dest[idx] = nil
 			continue

--- a/rows_test.go
+++ b/rows_test.go
@@ -1,0 +1,79 @@
+package vertigo
+
+import (
+	"bytes"
+	"context"
+	"database/sql/driver"
+	"encoding/binary"
+	"testing"
+
+	"github.com/vertica/vertica-sql-go/msgs"
+)
+
+func makeColumnDef() *msgs.BERowDescMsg {
+	cols := make([]*msgs.BERowDescColumnDef, 4)
+	cols[0] = &msgs.BERowDescColumnDef{FieldName: "a", AttribNum: 1, DataTypeOID: 6, DataTypeName: "integer", Length: 8}
+	cols[1] = &msgs.BERowDescColumnDef{FieldName: "b", AttribNum: 2, DataTypeOID: 9, DataTypeName: "varchar", Length: -1}
+	cols[2] = &msgs.BERowDescColumnDef{FieldName: "c", AttribNum: 3, DataTypeOID: 5, DataTypeName: "boolean", Length: 1}
+	cols[3] = &msgs.BERowDescColumnDef{FieldName: "d", AttribNum: 4, DataTypeOID: 6, DataTypeName: "integer", Length: 8}
+	return &msgs.BERowDescMsg{Columns: cols}
+}
+
+func mockRow() []byte {
+	buf := bytes.NewBuffer(make([]byte, 0, 30))
+	binary.Write(buf, binary.BigEndian, int16(4))
+	binary.Write(buf, binary.BigEndian, int32(3))
+	binary.Write(buf, binary.BigEndian, []byte("123"))
+	binary.Write(buf, binary.BigEndian, int32(5))
+	binary.Write(buf, binary.BigEndian, []byte("hello"))
+	binary.Write(buf, binary.BigEndian, int32(1))
+	binary.Write(buf, binary.BigEndian, false)
+	binary.Write(buf, binary.BigEndian, int32(3))
+	binary.Write(buf, binary.BigEndian, []byte("456"))
+	return buf.Bytes()
+}
+
+//Simulate loading a bunch of rows from messages and then extracting them with Next()
+func BenchmarkRows(b *testing.B) {
+	const rowCount = 10000
+	var msgType msgs.BEDataRowMsg
+	var mockData [rowCount][]byte
+	for i := 0; i < rowCount; i++ {
+		mockData[i] = mockRow()
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		rows := newRows(context.Background(), makeColumnDef(), "")
+		for i := 0; i < rowCount; i++ {
+			rowI, _ := msgType.CreateFromMsgBody(msgs.NewMsgBufferFromBytes(mockData[i]))
+			rows.addRow(rowI.(*msgs.BEDataRowMsg))
+		}
+		result := make([]driver.Value, 4)
+		for i := 0; i < rowCount; i++ {
+			rows.Next(result)
+		}
+	}
+}
+
+func BenchmarkRowsWithLimit(b *testing.B) {
+	const rowCount = 10000
+	vCtx := NewVerticaContext(context.Background())
+	vCtx.SetInMemoryResultRowLimit(1000)
+	var msgType msgs.BEDataRowMsg
+	var mockData [rowCount][]byte
+	for i := 0; i < rowCount; i++ {
+		mockData[i] = mockRow()
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		rows := newRows(vCtx, makeColumnDef(), "")
+		for i := 0; i < rowCount; i++ {
+			rowI, _ := msgType.CreateFromMsgBody(msgs.NewMsgBufferFromBytes(mockData[i]))
+			rows.addRow(rowI.(*msgs.BEDataRowMsg))
+		}
+		result := make([]driver.Value, 4)
+		for i := 0; i < rowCount; i++ {
+			rows.Next(result)
+		}
+	}
+}


### PR DESCRIPTION
I was curious about #43 and wanted to get an idea of where time was being spent in each. This should help anyone looking narrow down their searches.

Example of the current outputs:
```
BenchmarkRows-12    	     277	   4299277 ns/op	 3425337 B/op	  140019 allocs/op
BenchmarkRowsWithLimit-12    	     170	   6648526 ns/op	 4065688 B/op	  157967 allocs/op
```

Here are some fancy graphics:
CPU:
![profile001](https://user-images.githubusercontent.com/4331955/74466455-d83c2700-4e5c-11ea-8662-532cdc7f6258.png)

Memory:
![profile002](https://user-images.githubusercontent.com/4331955/74466466-dc684480-4e5c-11ea-86dc-15c0df8548d1.png)
