### PR TITLE
Handle named params with in clause

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ before_install:
   - sleep 60
 
 script:
-  - go test --locator localhost:5433 --user dbadmin -race .
-  - go test --locator localhost:5433 --user dbadmin --use_prepared_statements=0 -race .
+  - go test -race . -args --locator localhost:5433 --user dbadmin
+  - go test -race . -args --locator localhost:5433 --user dbadmin --use_prepared_statements=0
   - go test -race ./logger
   - docker exec -u dbadmin vertica_docker /opt/vertica/bin/vsql -c "SELECT SET_CONFIG_PARAMETER('SSLPrivateKey', '`cat ./resources/tests/ssl/root.key`');"
   - docker exec -u dbadmin vertica_docker /opt/vertica/bin/vsql -c "SELECT SET_CONFIG_PARAMETER('SSLCertificate', '`cat ./resources/tests/ssl/root.crt`');"
@@ -28,7 +28,7 @@ script:
   - docker exec -u dbadmin vertica_docker /opt/vertica/bin/vsql -c "ALTER DATABASE docker SET EnableSSL=1;"
   - docker exec -u dbadmin vertica_docker /opt/vertica/bin/admintools --tool stop_db --database docker
   - docker exec -u dbadmin vertica_docker /opt/vertica/bin/admintools --tool start_db --database docker
-  - go test --locator localhost:5433 --user dbadmin --tlsmode=server -race .
-  - go test --locator localhost:5433 --user dbadmin --tlsmode=server --use_prepared_statements=0 -race .
+  - go test -race . -args --locator localhost:5433 --user dbadmin --tlsmode=server
+  - go test -race . -args --locator localhost:5433 --user dbadmin --tlsmode=server --use_prepared_statements=0
   # go test --locator localhost:5433 --user dbadmin --tlsmode=server-strict -race .
   # go test --locator localhost:5433 --user dbadmin --tlsmode=server-strict --use_prepared_statements=0 -race .

--- a/parse/queryLex.go
+++ b/parse/queryLex.go
@@ -114,9 +114,17 @@ func (l *Lexer) skipUntil(val rune) {
 	}
 }
 
-func (l *Lexer) consumeToSpace() {
-	for !l.done() && !unicode.IsSpace(l.next()) {
+func (l *Lexer) consumeIdent() {
+	for !l.done() && !l.isEndIdent(l.next()) {
 	}
+}
+
+func (l *Lexer) isEndIdent(r rune) bool {
+	shouldEnd := unicode.IsSpace(r) || strings.ContainsRune(",)", r)
+	if shouldEnd {
+		l.backup()
+	}
+	return shouldEnd
 }
 
 func (l *Lexer) next() rune {
@@ -201,10 +209,7 @@ func lexNamedParam(l *Lexer) stateFunc {
 	l.next()
 	l.start = l.pos
 	// advance through the name
-	l.consumeToSpace()
-	if !l.done() || strings.HasSuffix(l.input[l.start:l.pos], "\n") {
-		l.backup() // move back before the whitespace character
-	}
+	l.consumeIdent()
 	l.onNamed(strings.ToUpper(l.input[l.start:l.pos]))
 	l.start = l.pos
 	l.output.WriteRune('?')

--- a/parse/queryLex_test.go
+++ b/parse/queryLex_test.go
@@ -84,6 +84,18 @@ func TestLexNamed(t *testing.T) {
 			expectedOutput: "select * from whatever where a = ? and b = ? and c = '@fooledYou'",
 		},
 		{
+			name:           "named params with in clause",
+			query:          "select * from whatever where a in (@first, @second)",
+			expectedNamed:  []string{"FIRST", "SECOND"},
+			expectedOutput: "select * from whatever where a in (?, ?)",
+		},
+		{
+			name:           "single named param with in clause",
+			query:          "select * from whatever where a in (@first)",
+			expectedNamed:  []string{"FIRST"},
+			expectedOutput: "select * from whatever where a in (?)",
+		},
+		{
 			name:           "with mixed case named parameters",
 			query:          "select * from whatever where a = @first and b = @fIrSt",
 			expectedNamed:  []string{"FIRST", "FIRST"},


### PR DESCRIPTION
Fixes #70

Renamed `consumeToSpace` to `consumeIdent` to better reflect its purpose. Instead of treating a `@identifier` as something that only ends on whitespace, it can end on `,` `)` or a whitespace.