### PR TITLE
Stop warning about parameter status updates

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -399,6 +399,8 @@ func (v *connection) defaultMessageHandler(bMsg msgs.BackEndMsg) (bool, error) {
 		}
 	case *msgs.BENoticeMsg:
 		break
+	case *msgs.BEParamStatusMsg:
+		connectionLogger.Debug("%v", msg)
 	default:
 		handled = false
 		err = fmt.Errorf("unhandled message: %v", msg)


### PR DESCRIPTION
Just got tired seeing a log of

```
Mar 10 09:33:08.771691 WARN connection: unhandled message: ParameterStatus: client_locale='en_US@collation=binary'
Mar 10 09:33:10.121297 WARN connection: unhandled message: ParameterStatus: standard_conforming_strings='on'
Mar 10 09:33:10.121336 WARN connection: unhandled message: ParameterStatus: MARS='off'
Mar 10 09:33:10.121355 WARN connection: unhandled message: ParameterStatus: client_locale='en_US@collation=binary'
Mar 10 09:33:12.049331 WARN connection: unhandled message: ParameterStatus: standard_conforming_strings='on'
Mar 10 09:33:12.049362 WARN connection: unhandled message: ParameterStatus: MARS='off'
Mar 10 09:33:12.049377 WARN connection: unhandled message: ParameterStatus: client_locale='en_US@collation=binary'
Mar 10 09:33:12.049978 WARN connection: unhandled message: ParameterStatus: standard_conforming_strings='on'
Mar 10 09:33:12.050005 WARN connection: unhandled message: ParameterStatus: MARS='off'
Mar 10 09:33:12.050047 WARN connection: unhandled message: ParameterStatus: client_locale='en_US@collation=binary'
...
```