### PR TITLE
Fixed parse query with escaped email value

### DIFF
--- a/parse/queryLex.go
+++ b/parse/queryLex.go
@@ -170,7 +170,7 @@ func lexQuery(l *Lexer) stateFunc {
 			return lexComment
 		}
 
-		if r == '\'' {
+		if r == '\'' && l.peek() != '\'' {
 			return lexString
 		}
 

--- a/parse/queryLex_test.go
+++ b/parse/queryLex_test.go
@@ -114,6 +114,12 @@ func TestLexNamed(t *testing.T) {
 			expectedOutput: "select * from whatever where a = ? and b = 'isn'''t",
 		},
 		{
+			name:           "with pre-escaped email string",
+			query:          "insert into table values('fo''o@bar.com', 2020)",
+			expectedNamed:  []string{},
+			expectedOutput: "insert into table values('fo''o@bar.com', 2020)",
+		},
+		{
 			name: "with a comment",
 			query: `select --some select stuff
 			* from whatever where a = @param`,


### PR DESCRIPTION
Hi there 👋 

We catch an error on exec query like that
```sql
sql> delete from table where email = 'foo''bar@goo.co' and created_at = '2020-12-21 ....'

Error: [42601] Syntax error at or near "2020"
```

The PR changes fixed this problem