### PR TITLE
Upgrade protocol version and testing framework

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.15', '1.14', '1.13']
+        go-version: ['1.16', '1.15', '1.14', '1.13']
 
     steps:
       - name: Check out repository
@@ -19,7 +19,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Set up a Vertica server
         env:
-          VERTICA_CE_URL: "https://vertica-community-edition-for-testing.s3.amazonaws.com/XCz9cp7m/vertica-10.1.0-0.x86_64.RHEL6.rpm"
+          VERTICA_CE_URL: "https://vertica-community-edition-for-testing.s3.amazonaws.com/XCz9cp7m/vertica-10.1.1-0.x86_64.RHEL6.rpm"
         run: |
           git clone https://github.com/jbfavre/docker-vertica.git
           curl $VERTICA_CE_URL --create-dirs -o docker-vertica/packages/vertica-ce.latest.rpm

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ vertica-sql-go is a native Go adapter for the Vertica (http://www.vertica.com) d
 
 Please check out [release notes](https://github.com/vertica/vertica-sql-go/releases) to learn about the latest improvements.
 
-vertica-sql-go has been tested with Vertica 10.1.1 and Go 1.13/1.14/1.15.
+vertica-sql-go has been tested with Vertica 10.1.1 and Go 1.13/1.14/1.15/1.16.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ vertica-sql-go is a native Go adapter for the Vertica (http://www.vertica.com) d
 
 Please check out [release notes](https://github.com/vertica/vertica-sql-go/releases) to learn about the latest improvements.
 
-vertica-sql-go has been tested with Vertica 10.1 and Go 1.13/1.14/1.15.
+vertica-sql-go has been tested with Vertica 10.1.1 and Go 1.13/1.14/1.15.
 
 ## Installation
 

--- a/driver.go
+++ b/driver.go
@@ -47,7 +47,7 @@ type Driver struct{}
 const (
 	driverName      string = "vertica-sql-go"
 	driverVersion   string = "1.1.1"
-	protocolVersion uint32 = 0x00030008
+	protocolVersion uint32 = 0x00030009
 )
 
 var driverLogger = logger.New("driver")


### PR DESCRIPTION
- Upgrade server version to 10.1.1 for CI tests
- Add Go v1.16 for CI tests
- Upgrade client supported protocol version from 3.8 to 3.9 (server behavior change, go client is unaffected)