### PR TITLE
Fixed the ping query: read result to avoid wrong query result

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -186,6 +186,10 @@ func (v *connection) Ping(ctx context.Context) error {
 	if err != nil {
 		return driver.ErrBadConn
 	}
+	var val interface{}
+	if err := rows.Next([]driver.Value{val}); err != nil {
+		return driver.ErrBadConn
+	}
 	rows.Close()
 	return nil
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -1107,17 +1107,7 @@ func TestUnexpectedResult(t *testing.T) {
 	_, err := connDB.Query("select throw_error('whatever')")
 	assertErr(t, err, "ERROR: whatever")
 
-	res, err := connDB.Query("select throw_error('whatever')")
-	if err == nil {
-		// Second query returns result of Ping query, check it
-		var test string
-		assertTrue(t, res.Next())
-		err = res.Scan(&test)
-		assertNoErr(t, err)
-		assertEqual(t, "1", test)
-		assertTrue(t, !res.Next())
-	}
-	// Finally fail test by correct assert
+	_, err = connDB.Query("select throw_error('whatever')")
 	assertErr(t, err, "ERROR: whatever")
 }
 


### PR DESCRIPTION
PR contains 2 commits:
 1. Added test, show issue
 2. Fixed issue

Issue details: 

When use_prepared_statements=0 second query always return success result `test:1`
