### PR TITLE
Fix #119

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -412,7 +412,7 @@ func (v *connection) handshake() error {
 
 		switch msg := bMsg.(type) {
 		case *msgs.BEErrorMsg:
-			return msg.ToErrorType()
+			return errorMsgToVError(msg)
 		case *msgs.BEReadyForQueryMsg:
 			v.transactionState = msg.TransactionState
 			return nil

--- a/msgs/bekeydatamsg.go
+++ b/msgs/bekeydatamsg.go
@@ -53,7 +53,7 @@ func (m *BEKeyDataMsg) CreateFromMsgBody(buf *msgBuffer) (BackEndMsg, error) {
 }
 
 func (m *BEKeyDataMsg) String() string {
-	return fmt.Sprintf("KeyData: BackendPID=%d, CancelKey=%08X'", m.BackendPID, m.CancelKey)
+	return fmt.Sprintf("KeyData: BackendPID=%d, CancelKey=%08X", m.BackendPID, m.CancelKey)
 }
 
 func init() {

--- a/stmt.go
+++ b/stmt.go
@@ -425,7 +425,7 @@ func (s *stmt) evaluateErrorMsg(msg *msgs.BEErrorMsg) error {
 	if msg.Severity == "ROLLBACK" {
 		s.rolledBack = true
 	}
-	return msg.ToErrorType()
+	return errorMsgToVError(msg)
 }
 
 func (s *stmt) prepareAndDescribe() error {
@@ -470,7 +470,7 @@ func (s *stmt) prepareAndDescribe() error {
 		switch msg := bMsg.(type) {
 		case *msgs.BEErrorMsg:
 			s.conn.sync()
-			return msg.ToErrorType()
+			return errorMsgToVError(msg)
 		case *msgs.BEParseCompleteMsg:
 			s.parseState = parseStateParsed
 		case *msgs.BERowDescMsg:


### PR DESCRIPTION
Fix #119
Introduce a new struct `VError` implementing [error](https://pkg.go.dev/builtin#error) interface. The error code can be retrieved by `err.ErrorCode`, and the SQL state can be retrieved by `err.SQLState`, etc.