### PR TITLE
Fix #127

### DIFF
--- a/parse/queryLex.go
+++ b/parse/queryLex.go
@@ -170,7 +170,7 @@ func lexQuery(l *Lexer) stateFunc {
 			return lexComment
 		}
 
-		if r == '\'' && l.peek() != '\'' {
+		if r == '\'' {
 			return lexString
 		}
 
@@ -195,9 +195,21 @@ func lexComment(l *Lexer) stateFunc {
 // lexString assumes we are starting inside the string and goes to the next ' rune
 // if it was an escaped quote like 'isn''t' lexQuery will drop us right back here to finish
 func lexString(l *Lexer) stateFunc {
-	l.skipUntil('\'')
+	l.skipQuotedLiteral()
 	l.writeChunk()
 	return lexQuery
+}
+func (l *Lexer) skipQuotedLiteral() {
+	for {
+		next := l.next()
+		if next == '\'' && l.peek() == '\'' {
+			l.next()
+			continue
+		}
+		if next == '\'' || next == eof {
+			return
+		}
+	}
 }
 
 // lexNamedParam replaces named params like @named with a ? while calling out to a consumer

--- a/parse/queryLex_test.go
+++ b/parse/queryLex_test.go
@@ -201,6 +201,11 @@ func TestLexPositional(t *testing.T) {
 			expected: "select * from table where a = 'replaced' and b = '?fooledYou'",
 		},
 		{
+			name:     "empty string",
+			query:    "select * from table where (a = ? or ? = '') and b > ?",
+                        expected: "select * from table where (a = 'replaced' or 'replaced' = '') and b > 'replaced'",
+		},
+		{
 			name: "? hidden in a comment",
 			query: `select
 			* from -- maybe broken?

--- a/parse/queryLex_test.go
+++ b/parse/queryLex_test.go
@@ -203,7 +203,7 @@ func TestLexPositional(t *testing.T) {
 		{
 			name:     "empty string",
 			query:    "select * from table where (a = ? or ? = '') and b > ?",
-                        expected: "select * from table where (a = 'replaced' or 'replaced' = '') and b > 'replaced'",
+			expected: "select * from table where (a = 'replaced' or 'replaced' = '') and b > 'replaced'",
 		},
 		{
 			name: "? hidden in a comment",


### PR DESCRIPTION
Lex has logic recognizing a SQL literals. It escapes `'` in the literal, for example `... WHERE column = 'lion''s paw'`, but it incorrectly handle empty string `... WHERE column = ''` in queries.