### PR TITLE
Limit max send message size to 8192 bytes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.16', '1.15', '1.14', '1.13']
+        go-version: ['1.17', '1.16', '1.15', '1.14', '1.13']
 
     steps:
       - name: Check out repository

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ vertica-sql-go is a native Go adapter for the Vertica (http://www.vertica.com) d
 
 Please check out [release notes](https://github.com/vertica/vertica-sql-go/releases) to learn about the latest improvements.
 
-vertica-sql-go has been tested with Vertica 11.0.1 and Go 1.13/1.14/1.15/1.16.
+vertica-sql-go has been tested with Vertica 11.0.1 and Go 1.13/1.14/1.15/1.16/1.17.
 
 ## Installation
 


### PR DESCRIPTION
To consistent with how the server works, the message send to server should be no larger than 8192 bytes.