### PR TITLE
Restore DNS Round Robin Behavior

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -274,73 +274,43 @@ func newConnection(connString string) (*connection, error) {
 	return result, nil
 }
 
-/*func (v *connection) establishSocketConnection() (net.Conn, error) {
-	// Failover: loop to try all hosts in the list
-	err_msg := ""
-	for i := 0; i < len(v.connHostsList); i++ {
-		// net.Dial will resolve the host to multiple IP addresses,
-		// and try each IP address in order until one succeeds.
-		conn, err := net.Dial("tcp", v.connHostsList[i])
-		if err != nil {
-			err_msg += fmt.Sprintf("\n  '%s': %s", v.connHostsList[i], err.Error())
-		} else {
-			if len(err_msg) != 0 {
-				connectionLogger.Debug("Failed to establish a connection to %s", err_msg)
-			}
-			connectionLogger.Debug("Established socket connection to %s", v.connHostsList[i])
-			v.connHostsList = v.connHostsList[i:]
-			return conn, err
-		}
-	}
-	// All of the hosts failed
-	return nil, fmt.Errorf("Failed to establish a connection to the primary server or any backup host.%s", err_msg)
-}*/
-
 func (v *connection) establishSocketConnection() (net.Conn, error) {
 	// Failover: loop to try all hosts in the list
 	err_msg := ""
 	for i := 0; i < len(v.connHostsList); i++ {
 		host, port, err := net.SplitHostPort(v.connHostsList[i])
 		if err != nil {
+			// no host-port pair identified
 			err_msg += fmt.Sprintf("\n  '%s': %s", host, err.Error())
-			//fmt.Printf("Failed to split host and port from network address: %s\n%s\n", v.connHostsList[i], err.Error());
 			continue
 		}
-		fmt.Printf("Trying Host: %s Port: %s\n", host, port)
 		ips, err := net.LookupIP(host)
 		if err != nil {
+			// failed to resolve any IPs from host
 			err_msg += fmt.Sprintf("\n  '%s': %s", host, err.Error())
-			//fmt.Printf("Failed to resolve IP address for %s\n%s\n", host, err.Error())
 			continue
 		}
-		fmt.Printf("IPs resolved by host: %s\n", ips)
 		r := rand.New(rand.NewSource(time.Now().Unix()))
 		for _, j := range r.Perm(len(ips)) {
+			// j comes from random permutation of indexes - ips[j] will access a random resolved ip
 			ip := net.IP.String(ips[j])
-			//returns nil if not an IPv4 address
 			if strings.HasPrefix(ip, "::") {
+				//handle IPV6 shorthand
 				ip = "[" + ip + "]"
 			}
-			// now we have a random ip from the list which cannot be a duplicate
 			addrString := ip + ":" + string(port)
-			fmt.Printf("Attempting to connect to %s\n", addrString)
 		    conn, err := net.Dial("tcp", addrString)
     
 		    if err != nil {
 		    	err_msg += fmt.Sprintf("\n  '%s': %s", v.connHostsList[i], err.Error())
-				fmt.Printf("Attempt Failed\n")
 		    } else {
-				fmt.Printf("Attempt Succeeded\n")
 		    	if len(err_msg) != 0 {
 		    		connectionLogger.Debug("Failed to establish a connection to %s", err_msg)
-					//fmt.Printf("Failed to establish a connection to %s\n", addrString)
 		    	}
-		    	connectionLogger.Debug("Established socket connection to %s", err_msg)
-				//fmt.Printf("Established socket connection to %s\n", addrString)
+		    	connectionLogger.Debug("Established socket connection to %s", addrString)
 		    	v.connHostsList = v.connHostsList[i:]
 		    	return conn, err
 		    }
-            
 		}
 	}
 	// All of the hosts failed

--- a/driver_test.go
+++ b/driver_test.go
@@ -60,6 +60,7 @@ var (
 	ctx                   context.Context
 )
 
+// The following assert functions compensate for Go having no native assertions
 func assertTrue(t *testing.T, v bool) {
 	t.Helper()
 


### PR DESCRIPTION
Restoration of DNS Round Robin Behavior.

This change is implemented in the establishSocketConnection() function. Unfortunately, net.Dial was doing a lot of the heavy lifting in the implementation that did not have DNS Round Robin Behavior, so the changes are slightly more involved that originally hoped. I've had to implement code to parse the host and port being stored in the net.Conn instance and handle DNS resolution. Then, after randomizing the resolved IPs, net.Dial can be used again if it given an IP address and port number. 

The comment to driver_test is simply a clarifying comment showing we're using our own asserts and not an imported module