### PR TITLE
Fix #87: Binary types support

### DIFF
--- a/driver_test.go
+++ b/driver_test.go
@@ -619,7 +619,7 @@ func TestValueTypes(t *testing.T) {
 	assertEqual(t, intervalMonthVal, "22")
 	assertEqual(t, timeVal.String()[11:23], "04:05:06.789")
 	assertEqual(t, timeTZVal.String()[11:25], "16:05:06 -0800")
-	assertEqual(t, hex.EncodeToString(varBinVal), "beefdead"))
+	assertEqual(t, hex.EncodeToString(varBinVal), "beefdead")
 	assertEqual(t, uuidVal, "372fd680-6a72-4003-96b0-10bbe78cd635")
 	assertEqual(t, lVarCharVal, "longer var char")
 	assertEqual(t, hex.EncodeToString(lVarBinaryVal), "deadbeef")

--- a/driver_test.go
+++ b/driver_test.go
@@ -623,7 +623,7 @@ func TestValueTypes(t *testing.T) {
 	assertEqual(t, uuidVal, "372fd680-6a72-4003-96b0-10bbe78cd635")
 	assertEqual(t, lVarCharVal, "longer var char")
 	assertEqual(t, hex.EncodeToString(lVarBinaryVal), "deadbeef")
-	assertEqual(t, hex.EncodeToString(binaryVal), "baadf00d")
+	assertEqual(t, hex.EncodeToString(binaryVal), "ba")
 	assertEqual(t, numericVal, 1.2345)
 
 	assertNext(t, rows)

--- a/driver_test.go
+++ b/driver_test.go
@@ -37,7 +37,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
-        "encoding/hex"
+	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"

--- a/driver_test.go
+++ b/driver_test.go
@@ -37,6 +37,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
+        "encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
@@ -578,11 +579,11 @@ func TestValueTypes(t *testing.T) {
 		intervalMonthVal string
 		timeVal          time.Time
 		timeTZVal        time.Time
-		varBinVal        string
+		varBinVal        []byte
 		uuidVal          string
 		lVarCharVal      string
-		lVarBinaryVal    string
-		binaryVal        string
+		lVarBinaryVal    []byte
+		binaryVal        []byte
 		numericVal       float64
 	)
 
@@ -618,11 +619,11 @@ func TestValueTypes(t *testing.T) {
 	assertEqual(t, intervalMonthVal, "22")
 	assertEqual(t, timeVal.String()[11:23], "04:05:06.789")
 	assertEqual(t, timeTZVal.String()[11:25], "16:05:06 -0800")
-	assertEqual(t, varBinVal, "5c3237365c3335375c3333365c323535")
+	assertEqual(t, hex.EncodeToString(varBinVal), "beefdead"))
 	assertEqual(t, uuidVal, "372fd680-6a72-4003-96b0-10bbe78cd635")
 	assertEqual(t, lVarCharVal, "longer var char")
-	assertEqual(t, lVarBinaryVal, "5c3333365c3235355c3237365c333537")
-	assertEqual(t, binaryVal, "5c323732")
+	assertEqual(t, hex.EncodeToString(lVarBinaryVal), "deadbeef")
+	assertEqual(t, hex.EncodeToString(binaryVal), "baadf00d")
 	assertEqual(t, numericVal, 1.2345)
 
 	assertNext(t, rows)

--- a/msgs/febindmsg.go
+++ b/msgs/febindmsg.go
@@ -33,7 +33,7 @@ package msgs
 // THE SOFTWARE.
 
 import (
-        "bytes"
+	"bytes"
 	"database/sql/driver"
 	"fmt"
 	"time"

--- a/msgs/febindmsg.go
+++ b/msgs/febindmsg.go
@@ -33,6 +33,7 @@ package msgs
 // THE SOFTWARE.
 
 import (
+        "bytes"
 	"database/sql/driver"
 	"fmt"
 	"time"
@@ -83,6 +84,12 @@ func (m *FEBindMsg) Flatten() ([]byte, byte) {
 			continue
 		case time.Time:
 			strVal = v.Format("2006-01-02T15:04:05.999999Z07:00")
+		case []uint8:
+			// Escape the byte value "\" with "\134"(octal for backslash)
+			v = bytes.ReplaceAll(v, []byte("\\"), []byte("\\134"))
+			buf.appendUint32(uint32(len(v)))
+			buf.appendBytes(v)
+			continue
 		default:
 			strVal = "??HELP??"
 		}

--- a/rows.go
+++ b/rows.go
@@ -36,7 +36,6 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"reflect"
@@ -127,8 +126,25 @@ func (r *rows) Next(dest []driver.Value) error {
 			dest[idx], err = parseTimestampTZColumn("0000-01-01 " + string(colVal))
 		case common.ColTypeInterval, common.ColTypeIntervalYM: // stays string
 			dest[idx] = string(colVal)
-		case common.ColTypeVarBinary, common.ColTypeLongVarBinary, common.ColTypeBinary: // to HEX string
-			dest[idx] = hex.EncodeToString(colVal)
+		case common.ColTypeVarBinary, common.ColTypeLongVarBinary, common.ColTypeBinary:
+			// to []byte; convert escaped octal (e.g. \261) into byte with \\ for \
+			var out []byte
+			for len(colVal) > 0 {
+				c := colVal[0]
+				if c == '\\' {
+					if colVal[1] == '\\' {  // escaped \
+						colVal = colVal[2:]
+					} else {                // A \xxx octal string
+						x, _ := strconv.ParseInt(string(colVal[1:4]), 8, 32)
+						c = byte(x)
+						colVal = colVal[4:]
+					}
+				} else {
+					colVal = colVal[1:]
+				}
+				out = append(out, c)
+			}
+			dest[idx] = out
 		default:
 			dest[idx] = string(colVal)
 		}

--- a/rows.go
+++ b/rows.go
@@ -132,9 +132,9 @@ func (r *rows) Next(dest []driver.Value) error {
 			for len(colVal) > 0 {
 				c := colVal[0]
 				if c == '\\' {
-					if colVal[1] == '\\' {  // escaped \
+					if colVal[1] == '\\' { // escaped \
 						colVal = colVal[2:]
-					} else {                // A \xxx octal string
+					} else { // A \xxx octal string
 						x, _ := strconv.ParseInt(string(colVal[1:4]), 8, 32)
 						c = byte(x)
 						colVal = colVal[4:]


### PR DESCRIPTION
Credit to @watercraft 

- When querying BINARY, VARBINARY or LONG VARBINARY data, the returned object type changes from `string` to `[]byte`. This fix handles escaped backslash \\ correctly.
- When use_prepared_statements=1, query parameter value can be sent as `[]byte`.