### PR TITLE
Add default connection database name

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ func main() {
 
     // Create a connection to our database. Connection is lazy and won't
     // happen until it's used.
-    connDB, err := sql.Open("vertica", "vertica://dbadmin:@localhost:5433/dbadmin")
+    connDB, err := sql.Open("vertica", "vertica://dbadmin:@localhost:5433/db1?connection_load_balance=1")
 
     if err != nil {
         testLogger.Fatal(err.Error())

--- a/connection.go
+++ b/connection.go
@@ -299,18 +299,18 @@ func (v *connection) establishSocketConnection() (net.Conn, error) {
 				ip = "[" + ip + "]"
 			}
 			addrString := ip + ":" + string(port)
-		    conn, err := net.Dial("tcp", addrString)
-    
-		    if err != nil {
-		    	err_msg += fmt.Sprintf("\n  '%s': %s", v.connHostsList[i], err.Error())
-		    } else {
-		    	if len(err_msg) != 0 {
-		    		connectionLogger.Debug("Failed to establish a connection to %s", err_msg)
-		    	}
-		    	connectionLogger.Debug("Established socket connection to %s", addrString)
-		    	v.connHostsList = v.connHostsList[i:]
-		    	return conn, err
-		    }
+			conn, err := net.Dial("tcp", addrString)
+
+			if err != nil {
+				err_msg += fmt.Sprintf("\n  '%s': %s", v.connHostsList[i], err.Error())
+			} else {
+				if len(err_msg) != 0 {
+					connectionLogger.Debug("Failed to establish a connection to %s", err_msg)
+				}
+				connectionLogger.Debug("Established socket connection to %s", addrString)
+				v.connHostsList = v.connHostsList[i:]
+				return conn, err
+			}
 		}
 	}
 	// All of the hosts failed
@@ -419,18 +419,17 @@ func (v *connection) handshake() error {
 		return fmt.Errorf("connection string must have a non-empty user name")
 	}
 
-	if len(v.connURL.Path) <= 1 {
-		return fmt.Errorf("connection string must include a database name")
+	dbName := ""
+	if len(v.connURL.Path) > 1 {
+		dbName = v.connURL.Path[1:]
 	}
-
-	path := v.connURL.Path[1:]
 
 	msg := &msgs.FEStartupMsg{
 		ProtocolVersion: protocolVersion,
 		DriverName:      driverName,
 		DriverVersion:   driverVersion,
 		Username:        userName,
-		Database:        path,
+		Database:        dbName,
 		SessionID:       v.sessionID,
 		ClientPID:       v.clientPID,
 	}

--- a/driver_test.go
+++ b/driver_test.go
@@ -1228,10 +1228,10 @@ func init() {
 			testLogger.Fatal("could not register tls config: %v", err)
 		}
 	}
-	myDBConnectString = "vertica://" + *verticaUserName + ":" + *verticaPassword + "@" + *verticaHostPort + "/" + *verticaUserName + "?" + usePreparedStmtsString + "&tlsmode=" + *tlsMode
-	otherConnectString = "vertica://TestGuy:TestGuyPass@" + *verticaHostPort + "/TestGuy?tlsmode=" + *tlsMode
-	badConnectString = "vertica://TestGuy:TestGuyBadPass@" + *verticaHostPort + "/TestGuy?tlsmode=" + *tlsMode
-	failoverConnectString = "vertica://" + *verticaUserName + ":" + *verticaPassword + "@badHost" + "/" + *verticaUserName + "?backup_server_node=abc.com:100000," + *verticaHostPort + ",localhost:port"
+	myDBConnectString = "vertica://" + *verticaUserName + ":" + *verticaPassword + "@" + *verticaHostPort + "?" + usePreparedStmtsString + "&tlsmode=" + *tlsMode
+	otherConnectString = "vertica://TestGuy:TestGuyPass@" + *verticaHostPort + "/?tlsmode=" + *tlsMode
+	badConnectString = "vertica://TestGuy:TestGuyBadPass@" + *verticaHostPort + "/?tlsmode=" + *tlsMode
+	failoverConnectString = "vertica://" + *verticaUserName + ":" + *verticaPassword + "@badHost" + "?backup_server_node=abc.com:100000," + *verticaHostPort + ",localhost:port"
 
 	ctx = context.Background()
 }


### PR DESCRIPTION
The connection string requires a database name:
```
vertica://(user):(password)@(host):(port)/(database)?(queryArgs)
```
After changes, the connection string can in the form of
```
vertica://(user):(password)@(host):(port)?(queryArgs)
or
vertica://(user):(password)@(host):(port)/?(queryArgs)
```
The client uses empty string as default database name, and the server will try to log into the current running database.