### PR TITLE
Adding ClientOSHostname and Workload properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Currently supported query arguments are:
 | client_label   | Sets a label for the connection on the server. This value appears in the `client_label` column of the SESSIONS system table. | (default) vertica-sql-go-{version}-{pid}-{timestamp} |
 | autocommit     | Controls whether the connection automatically commits transactions. | 1 = (default) on <br>0 = off|
 | oauth_access_token | To authenticate via OAuth, provide an OAuth Access Token that authorizes a user to the database. | unspecified by default, if specified then *user* is optional |
+| workload | Sets workload property of the session, enabling use of workload routing | empty string by default. Valid values are workload names that already exist in a workload routing rule on the server. If a workload name that doesn't exist is entered, the server will reject it and it will be set to the default empty string |
 
 To ping the server and validate a connection (as the connection isn't necessarily created at that moment), simply call the *PingContext()* method.
 

--- a/connection.go
+++ b/connection.go
@@ -113,6 +113,7 @@ type connection struct {
 	serverTZOffset   string
 	dead             bool // used if a ROLLBACK severity error is encountered
 	sessMutex        sync.Mutex
+	workload         string
 }
 
 // Begin - Begin starts and returns a new transaction. (DEPRECATED)
@@ -259,6 +260,9 @@ func newConnection(connString string) (*connection, error) {
 	if sslFlag == "" {
 		sslFlag = tlsModeNone
 	}
+
+	// Read Workload flag
+	result.workload = result.connURL.Query().Get("workload");
 
 	result.conn, err = result.establishSocketConnection()
 
@@ -444,6 +448,7 @@ func (v *connection) handshake() error {
 		ClientPID:        v.clientPID,
 		Autocommit:       v.autocommit,
 		OAuthAccessToken: v.oauthaccesstoken,
+		Workload:         v.workload,
 	}
 
 	if err := v.sendMessage(msg); err != nil {

--- a/driver_test.go
+++ b/driver_test.go
@@ -1201,7 +1201,7 @@ func TestWorkloadConnectionProperty(t *testing.T) {
 	var workload string
 	for rows.Next() {
 		assertNoErr(t, rows.Scan(&workload))
-		assertEqual(t, client_label, "workload: golangWorkload")
+		assertEqual(t, workload, "workload: golangWorkload")
 	}
 }
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -1205,6 +1205,24 @@ func TestWorkloadConnectionProperty(t *testing.T) {
 	}
 }
 
+func testClientOSHostnameProperty(t *testing.T) {
+	connDB := openConnection(t)
+	defer closeConnection(t, connDB)
+	rows, err := connDB.QueryContext(ctx, "SELECT client_os_hostname FROM current_session")
+	assertNoErr(t, err)
+	defer rows.Close()
+
+	var client_os_hostname, err = os.Hostname()
+	if err == nil { 
+		client_os_hostname = "";
+	}
+	var server_side_client_os_hostname string
+	for rows.Next() {
+		assertNoErr(t, rows.Scan(&server_side_client_os_hostname))
+		assertEqual(t, server_side_client_os_hostname, client_os_hostname)
+	}
+}
+
 var verticaUserName = flag.String("user", "dbadmin", "the user name to connect to Vertica")
 var verticaPassword = flag.String("password", os.Getenv("VERTICA_TEST_PASSWORD"), "Vertica password for this user")
 var verticaHostPort = flag.String("locator", "localhost:5433", "Vertica's host and port")

--- a/driver_test.go
+++ b/driver_test.go
@@ -1212,9 +1212,10 @@ func testClientOSHostnameProperty(t *testing.T) {
 	assertNoErr(t, err)
 	defer rows.Close()
 
-	var client_os_hostname, err = os.Hostname()
+	var client_os_hostname = ""
+	hostname, err := os.Hostname()
 	if err == nil { 
-		client_os_hostname = "";
+		client_os_hostname = hostname;
 	}
 	var server_side_client_os_hostname string
 	for rows.Next() {

--- a/msgs/festartupmsg.go
+++ b/msgs/festartupmsg.go
@@ -35,6 +35,7 @@ package msgs
 import (
 	"fmt"
 	"os/user"
+	"os"
 
 	"github.com/elastic/go-sysinfo"
 )
@@ -70,6 +71,11 @@ func (m *FEStartupMsg) Flatten() ([]byte, byte) {
 	currentUser, err := user.Current()
 	if err == nil {
 		m.OSUsername = currentUser.Username
+	}
+
+	m.ClientOSHostname, err = os.Hostname()
+	if err == nil { 
+		m.ClientOSHostname = "";
 	}
 
 	buf := newMsgBuffer()

--- a/msgs/festartupmsg.go
+++ b/msgs/festartupmsg.go
@@ -119,7 +119,7 @@ func (m *FEStartupMsg) String() string {
 		m.ClientOS,
 		m.OSUsername,
 		m.Autocommit,
-		len(m.OAuthAccessToken)),
+		len(m.OAuthAccessToken),
 		m.ClientOSHostname,
-		m.Workload
+		m.Workload)
 }

--- a/msgs/festartupmsg.go
+++ b/msgs/festartupmsg.go
@@ -73,8 +73,8 @@ func (m *FEStartupMsg) Flatten() ([]byte, byte) {
 		m.OSUsername = currentUser.Username
 	}
 
-	m.ClientOSHostname, err = os.Hostname()
-	if err == nil { 
+	m.ClientOSHostname, err := os.Hostname()
+	if err != nil { 
 		m.ClientOSHostname = "";
 	}
 

--- a/msgs/festartupmsg.go
+++ b/msgs/festartupmsg.go
@@ -52,6 +52,8 @@ type FEStartupMsg struct {
 	OSUsername       string
 	Autocommit       string
 	OAuthAccessToken string
+	ClientOSHostname string
+	Workload         string
 }
 
 // Flatten docs
@@ -97,6 +99,8 @@ func (m *FEStartupMsg) Flatten() ([]byte, byte) {
 	buf.appendLabeledString("client_os", m.ClientOS)
 	buf.appendLabeledString("client_os_user_name", m.OSUsername)
 	buf.appendLabeledString("autocommit", m.Autocommit)
+	buf.appendLabeledString("client_os_hostname", m.ClientOSHostname)
+	buf.appendLabeledString("workload", m.Workload)
 	buf.appendBytes([]byte{0})
 
 	return buf.bytes(), 0
@@ -104,7 +108,7 @@ func (m *FEStartupMsg) Flatten() ([]byte, byte) {
 
 func (m *FEStartupMsg) String() string {
 	return fmt.Sprintf(
-		"Startup (packet): ProtocolVersion:%08X, DriverName='%s', DriverVersion='%s', UserName='%s', Database='%s', SessionID='%s', ClientPID=%d, ClientOS='%s', ClientOSUserName='%s', Autocommit='%s', OAuthAccessToken=<length:%d>",
+		"Startup (packet): ProtocolVersion:%08X, DriverName='%s', DriverVersion='%s', UserName='%s', Database='%s', SessionID='%s', ClientPID=%d, ClientOS='%s', ClientOSUserName='%s', Autocommit='%s', OAuthAccessToken=<length:%d>, ClientOSHostname='%s', Workload='%s'",
 		m.ProtocolVersion,
 		m.DriverName,
 		m.DriverVersion,
@@ -115,5 +119,7 @@ func (m *FEStartupMsg) String() string {
 		m.ClientOS,
 		m.OSUsername,
 		m.Autocommit,
-		len(m.OAuthAccessToken))
+		len(m.OAuthAccessToken)),
+		m.ClientOSHostname,
+		m.Workload
 }

--- a/msgs/festartupmsg.go
+++ b/msgs/festartupmsg.go
@@ -73,9 +73,10 @@ func (m *FEStartupMsg) Flatten() ([]byte, byte) {
 		m.OSUsername = currentUser.Username
 	}
 
-	m.ClientOSHostname, err := os.Hostname()
-	if err != nil { 
-		m.ClientOSHostname = "";
+	m.ClientOSHostname = ""
+	hostname, err := os.Hostname()
+	if err == nil { 
+		m.ClientOSHostname = hostname;
 	}
 
 	buf := newMsgBuffer()


### PR DESCRIPTION
This PR adds two properties passed to the server in the startup request message - client_os_hostname, and workload. 

Tests for both are included and the README is updated for workload only - client_os_hostname is determined by the driver, not passed in by the user. 