### PR TITLE
PDC Custom Dialer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
         run: |
           docker run -d -p 5433:5433 -p 5444:5444 \
             --name vertica_docker --network my-network \
-            opentext/vertica-ce:24.4.0-0
+            vertica/vertica-ce:latest
           echo "Vertica startup ..."
           until docker exec vertica_docker test -f /data/vertica/VMart/agent_start.out; do \
             echo "..."; \


### PR DESCRIPTION
Add Custom Dialer feature to vertica-sql-go driver

SOCKS parser dialer 1:
socksDialer, _ := proxy.SOCKS5("tcp", "127.0.0.1:5555", nil, &net.Dialer{})
    customDialer := func(ctx context.Context, network, addr string) (net.Conn, error) {
        return socksDialer.Dial(network, addr)
    }
    connector, _ := vertica.NewConnector("vertica://dbadmin:vdb@10.20.73.219:5433/VMart", customDialer)
    connDB := sql.OpenDB(connector)
 
Net dialer 2:
customDialer2 := func(ctx context.Context, network, addr string) (net.Conn, error) { return net.Dial("tcp", addr) }
    connector, _ := vertica.NewConnector("vertica://dbadmin:vdb@10.20.73.219:5433/VMart", customDialer2)
    connDB := sql.OpenDB(connector)
 
No Dialer:
connDB, err := sql.Open("vertica", "vertica://dbadmin:vdb@10.20.73.219:5433/VMart")

