### PR TITLE
Handling valid SQL formatting and statement variations

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -837,6 +837,21 @@ func (v *connection) sync() error {
 	return nil
 }
 
+func (v *connection) drainUntilReady() error {
+	for {
+		bem, err := v.recvMessage()
+		if err != nil {
+			return err
+		}
+
+		if _, ok := bem.(*msgs.BEReadyForQueryMsg); ok {
+			return nil
+		}
+
+		_, _ = v.defaultMessageHandler(bem)
+	}
+}
+
 func (v *connection) LastNotice() string {
     return v.lastNotice
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -1342,6 +1342,94 @@ func TestLocalCopy(t *testing.T) {
 	_, err = connDB.ExecContext(ctx, copySQL)
 	assertNoErr(t, err)
 
+	assertCopyCSVValues(t, connDB)
+}
+
+func TestLocalCopyCSVMultipleFiles(t *testing.T) {
+	connDB := openConnection(t, "test_copy_local_pre")
+	defer closeConnection(t, connDB, "test_copy_local_post")
+
+	dataPath, err := filepath.Abs("./resources/csv/sample_data.csv")
+	assertNoErr(t, err)
+
+	body, err := ioutil.ReadFile(dataPath)
+	assertNoErr(t, err)
+
+	tmpDir := t.TempDir()
+	secondPath := filepath.Join(tmpDir, "sample_data_2.csv")
+	thirdPath := filepath.Join(tmpDir, "sample_data_3.csv")
+	assertNoErr(t, ioutil.WriteFile(secondPath, body, 0600))
+	assertNoErr(t, ioutil.WriteFile(thirdPath, body, 0600))
+
+	copySQL := fmt.Sprintf(
+		"COPY csv_values FROM LOCAL '%s', '%s', '%s' DELIMITER ','",
+		filepath.ToSlash(dataPath),
+		filepath.ToSlash(secondPath),
+		filepath.ToSlash(thirdPath),
+	)
+	_, err = connDB.ExecContext(ctx, copySQL)
+	assertNoErr(t, err)
+
+	rows, err := connDB.QueryContext(ctx, "SELECT COUNT(*) FROM csv_values")
+	assertNoErr(t, err)
+	defer rows.Close()
+
+	assertNext(t, rows)
+	var count int
+	assertNoErr(t, rows.Scan(&count))
+	assertEqual(t, count, 15)
+	assertNoNext(t, rows)
+}
+
+func TestLocalCopyCSVMultipleFilesMissingFile(t *testing.T) {
+	connDB := openConnection(t, "test_copy_local_pre")
+	defer closeConnection(t, connDB, "test_copy_local_post")
+
+	dataPath, err := filepath.Abs("./resources/csv/sample_data.csv")
+	assertNoErr(t, err)
+
+	body, err := ioutil.ReadFile(dataPath)
+	assertNoErr(t, err)
+
+	tmpDir := t.TempDir()
+	secondPath := filepath.Join(tmpDir, "sample_data_2.csv")
+	missingPath := filepath.Join(tmpDir, "missing_sample_data.csv")
+	assertNoErr(t, ioutil.WriteFile(secondPath, body, 0600))
+
+	copySQL := fmt.Sprintf(
+		"COPY csv_values FROM LOCAL '%s', '%s', '%s' DELIMITER ','",
+		filepath.ToSlash(dataPath),
+		filepath.ToSlash(secondPath),
+		filepath.ToSlash(missingPath),
+	)
+	_, err = connDB.ExecContext(ctx, copySQL)
+	assertErr(t, err, "no such file or directory")
+}
+
+func TestLocalCopyCSVMultipleFilesSchemaMismatch(t *testing.T) {
+	connDB := openConnection(t, "test_copy_local_pre")
+	defer closeConnection(t, connDB, "test_copy_local_post")
+
+	dataPath, err := filepath.Abs("./resources/csv/sample_data.csv")
+	assertNoErr(t, err)
+
+	tmpDir := t.TempDir()
+	badSchemaPath := filepath.Join(tmpDir, "sample_data_bad_schema.csv")
+	badContent := []byte("john,555,extra_column\nroger,456,extra_column\n")
+	assertNoErr(t, ioutil.WriteFile(badSchemaPath, badContent, 0600))
+
+	copySQL := fmt.Sprintf(
+		"COPY csv_values FROM LOCAL '%s', '%s' DELIMITER ',' ABORT ON ERROR",
+		filepath.ToSlash(dataPath),
+		filepath.ToSlash(badSchemaPath),
+	)
+	_, err = connDB.ExecContext(ctx, copySQL)
+	assertTrue(t, err != nil)
+}
+
+func assertCopyCSVValues(t *testing.T, connDB *sql.DB) {
+	t.Helper()
+
 	rows, err := connDB.QueryContext(ctx, "SELECT name,id FROM csv_values ORDER BY name")
 	assertNoErr(t, err)
 	defer rows.Close()
@@ -1365,6 +1453,54 @@ func TestLocalCopy(t *testing.T) {
 
 	assertEqual(t, matched, 5)
 	assertNoNext(t, rows)
+}
+
+func TestLocalCopySQLVariants(t *testing.T) {
+	connDB := openConnection(t, "test_copy_local_pre")
+	defer closeConnection(t, connDB, "test_copy_local_post")
+
+	dataPath, err := filepath.Abs("./resources/csv/sample_data.csv")
+	assertNoErr(t, err)
+
+	testCases := []struct {
+		name        string
+		sqlTemplate string
+	}{
+		{
+			name:        "leading comment",
+			sqlTemplate: "-- daily load\nCOPY csv_values FROM LOCAL '%s' DELIMITER ','",
+		},
+		{
+			name:        "leading whitespace",
+			sqlTemplate: "\n\n COPY csv_values FROM LOCAL '%s' DELIMITER ','",
+		},
+		{
+			name:        "tabs between keywords",
+			sqlTemplate: "COPY csv_values FROM\tLOCAL\t'%s' DELIMITER ','",
+		},
+		{
+			name:        "inline block comment",
+			sqlTemplate: "COPY csv_values FROM /*note*/ LOCAL '%s' DELIMITER ','",
+		},
+		{
+			name:        "line comment between from and local",
+			sqlTemplate: "COPY csv_values FROM --note\nLOCAL '%s' DELIMITER ','",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, err = connDB.ExecContext(ctx, "DELETE FROM csv_values")
+			assertNoErr(t, err)
+
+			copySQL := fmt.Sprintf(tc.sqlTemplate, filepath.ToSlash(dataPath))
+			_, err = connDB.ExecContext(ctx, copySQL)
+			assertNoErr(t, err)
+
+			assertCopyCSVValues(t, connDB)
+		})
+	}
 }
 
 // Issue 44 : error during parsing of prepared statement causes perpetual error state
@@ -1406,6 +1542,45 @@ func TestLocalCopyJSON(t *testing.T) {
 	}
 
 	assertEqual(t, matched, 5)
+	assertNoNext(t, rows)
+}
+
+func TestLocalCopyJSONMultipleFiles(t *testing.T) {
+	connDB := openConnection(t, "test_copy_local_json_pre")
+	defer closeConnection(t, connDB, "test_copy_local_json_post")
+
+	dataPath, err := filepath.Abs("./resources/json/sample_data.json")
+	assertNoErr(t, err)
+
+	body, err := ioutil.ReadFile(dataPath)
+	assertNoErr(t, err)
+
+	tmpDir := t.TempDir()
+	secondPath := filepath.Join(tmpDir, "sample_data_2.json")
+	assertNoErr(t, ioutil.WriteFile(secondPath, body, 0600))
+
+	_, err = connDB.ExecContext(ctx, "DROP TABLE IF EXISTS json_values_rejects")
+	assertNoErr(t, err)
+	defer func() {
+		_, _ = connDB.ExecContext(ctx, "DROP TABLE IF EXISTS json_values_rejects")
+	}()
+
+	copySQL := fmt.Sprintf(
+		"COPY json_values FROM LOCAL '%s', '%s' PARSER FJSONPARSER() REJECTED DATA AS TABLE json_values_rejects",
+		filepath.ToSlash(dataPath),
+		filepath.ToSlash(secondPath),
+	)
+	_, err = connDB.ExecContext(ctx, copySQL)
+	assertNoErr(t, err)
+
+	rows, err := connDB.QueryContext(ctx, "SELECT COUNT(*) FROM json_values")
+	assertNoErr(t, err)
+	defer rows.Close()
+
+	assertNext(t, rows)
+	var count int
+	assertNoErr(t, rows.Scan(&count))
+	assertEqual(t, count, 10)
 	assertNoNext(t, rows)
 }
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -1404,6 +1404,13 @@ func TestLocalCopyCSVMultipleFilesMissingFile(t *testing.T) {
 	)
 	_, err = connDB.ExecContext(ctx, copySQL)
 	assertErr(t, err, "no such file or directory")
+	
+	// Verify connection is still usable after error
+	// drainUntilReady() should have restored protocol state
+	var result int
+	err = connDB.QueryRowContext(ctx, "SELECT 1").Scan(&result)
+	assertNoErr(t, err)
+	assertEqual(t, result, 1)
 }
 
 func TestLocalCopyCSVMultipleFilesSchemaMismatch(t *testing.T) {
@@ -1425,6 +1432,13 @@ func TestLocalCopyCSVMultipleFilesSchemaMismatch(t *testing.T) {
 	)
 	_, err = connDB.ExecContext(ctx, copySQL)
 	assertTrue(t, err != nil)
+	
+	// Verify connection is still usable after error
+	// drainUntilReady() should have restored protocol state
+	var result int
+	err = connDB.QueryRowContext(ctx, "SELECT 1").Scan(&result)
+	assertNoErr(t, err)
+	assertEqual(t, result, 1)
 }
 
 func assertCopyCSVValues(t *testing.T, connDB *sql.DB) {

--- a/stmt.go
+++ b/stmt.go
@@ -33,6 +33,7 @@ package vertigo
 // THE SOFTWARE.
 
 import (
+	"bytes"
 	"context"
 	"database/sql/driver"
 	"errors"
@@ -45,6 +46,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/vertica/vertica-sql-go/common"
 	"github.com/vertica/vertica-sql-go/logger"
@@ -55,7 +57,6 @@ import (
 var (
 	stmtLogger        = logger.New("stmt")
 	emailRegexPattern = regexp.MustCompile(`[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}`)
-	copyLocalRegex    = regexp.MustCompile(`(?is)\bFROM\s+LOCAL\s+'((?:''|[^'])*)'`)
 )
 
 type parseState int
@@ -318,27 +319,26 @@ func (s *stmt) QueryContextRaw(ctx context.Context, baseArgs []driver.NamedValue
 	for _, statementSQL := range statements {
 		execSQL := statementSQL
 		execCtx := ctx
-		var localFile *os.File
+		var localFiles []*os.File
 
-		if rewrittenSQL, localPath, isLocal := rewriteLocalCopyToSTDIN(statementSQL); isLocal {
+		if rewrittenSQL, localPaths, isLocal := rewriteLocalCopyToSTDIN(statementSQL); isLocal {
 			execSQL = rewrittenSQL
-			localFile, err = os.Open(filepath.Clean(localPath))
-			if err != nil {
-				return newEmptyRows(), err
+			var openErr error
+			localFiles, openErr = openLocalCopyFiles(localPaths)
+			if openErr != nil {
+				return newEmptyRows(), openErr
 			}
 
 			vCtx := NewVerticaContext(ctx)
 			if parentCtx, ok := ctx.(VerticaContext); ok {
 				_ = vCtx.SetCopyBlockSizeBytes(parentCtx.GetCopyBlockSizeBytes())
 			}
-			_ = vCtx.SetCopyInputStream(localFile)
+			_ = vCtx.SetCopyInputStream(multiReaderFromFiles(localFiles))
 			execCtx = vCtx
 		}
 
 		resultSet, runErr := s.runSimpleStatement(execCtx, execSQL)
-		if localFile != nil {
-			_ = localFile.Close()
-		}
+		closeLocalCopyFiles(localFiles)
 		if runErr != nil {
 			return newEmptyRows(), runErr
 		}
@@ -390,7 +390,10 @@ func (s *stmt) verifyLocalFiles(msg *msgs.BEVerifyLoadFilesMsg) error {
 		fileSizes[idx] = uint64(fileInfo.Size())
 	}
 
-	return s.conn.sendMessage(&msgs.FEVerifyLoadFiles{FileNames: msg.FileList, FileSizes: fileSizes})
+	return s.conn.sendMessage(&msgs.FEVerifyLoadFiles{
+		FileNames: msg.FileList,
+		FileSizes: fileSizes,
+	})
 }
 
 func (s *stmt) copyLocalFile(ctx context.Context, fileName string) error {
@@ -459,6 +462,9 @@ func (s *stmt) runSimpleStatement(ctx context.Context, sql string) (*rows, error
 		case *msgs.BECmdCompleteMsg, *msgs.BEParseCompleteMsg:
 			continue
 		case *msgs.BEErrorMsg:
+			if drainErr := s.conn.drainUntilReady(); drainErr != nil {
+				return newEmptyRows(), drainErr
+			}
 			return newEmptyRows(), s.evaluateErrorMsg(msg)
 		case *msgs.BEEmptyQueryResponseMsg:
 			return newEmptyRows(), nil
@@ -580,26 +586,348 @@ func (s *stmt) evaluateErrorMsg(msg *msgs.BEErrorMsg) error {
 	return errorMsgToVError(msg)
 }
 
-func rewriteLocalCopyToSTDIN(statement string) (string, string, bool) {
-	match := copyLocalRegex.FindStringSubmatchIndex(statement)
-	if len(match) < 4 {
-		return statement, "", false
-	}
-
-	localPath := statement[match[2]:match[3]]
-	localPath = strings.ReplaceAll(localPath, "''", "'")
-	rewritten := statement[:match[0]] + "FROM STDIN" + statement[match[1]:]
-
-	return rewritten, localPath, true
-}
-
 // isLocalCopyStatement reports whether the statement is a COPY ... FROM LOCAL ...
 // command. Such statements must use the simple query protocol because the server
 // enters the GetLocalFileInfo state immediately after FEExecuteMsg is processed,
 // making the trailing FEFlushMsg sent by bindAndExecute invalid in that state.
 func (s *stmt) isLocalCopyStatement() bool {
-	upper := strings.ToUpper(strings.TrimSpace(s.command))
-	return strings.HasPrefix(upper, "COPY") && strings.Contains(upper, "FROM LOCAL")
+	statements := parse.SplitStatements(s.command)
+	if len(statements) != 1 {
+		return false
+	}
+	_, ok := analyzeLocalCopyStatement(statements[0])
+	return ok
+}
+
+func openLocalCopyFiles(paths []string) ([]*os.File, error) {
+	files := make([]*os.File, 0, len(paths))
+	for _, localPath := range paths {
+		localFile, openErr := os.Open(filepath.Clean(localPath))
+		if openErr != nil {
+			closeLocalCopyFiles(files)
+			return nil, openErr
+		}
+		files = append(files, localFile)
+	}
+	return files, nil
+}
+
+func closeLocalCopyFiles(files []*os.File) {
+	for _, localFile := range files {
+		_ = localFile.Close()
+	}
+}
+
+func multiReaderFromFiles(files []*os.File) io.Reader {
+	if len(files) == 1 {
+		return files[0]
+	}
+	// Rewriting LOCAL file lists to a single STDIN stream loses the server's
+	// native file boundary handling. Reinsert a line break only when a source
+	// file does not already end with one so adjacent text records do not merge.
+	readers := make([]io.Reader, 0, len(files)*2)
+	for idx, localFile := range files {
+		readers = append(readers, localFile)
+		if idx < len(files)-1 && fileNeedsTrailingNewline(localFile) {
+			readers = append(readers, bytes.NewReader([]byte{'\n'}))
+		}
+	}
+	return io.MultiReader(readers...)
+}
+
+func fileNeedsTrailingNewline(fileHandle *os.File) bool {
+	fileInfo, err := fileHandle.Stat()
+	if err != nil || fileInfo.Size() == 0 {
+		return false
+	}
+
+	lastByte := []byte{0}
+	if _, err = fileHandle.ReadAt(lastByte, fileInfo.Size()-1); err != nil {
+		return false
+	}
+
+	return lastByte[0] != '\n' && lastByte[0] != '\r'
+}
+
+type sqlToken struct {
+	text  string
+	start int
+	end   int
+}
+
+type localCopyAnalysis struct {
+	fromStart   int
+	suffixStart int
+	paths       []string
+}
+
+func topLevelSQLTokens(statement string) []sqlToken {
+	tokens := make([]sqlToken, 0, 16)
+	var current strings.Builder
+	tokenStart := -1
+	// Tokenize only top-level SQL words and ignore quoted/commented regions so
+	// keywords inside literals/comments do not affect LOCAL COPY detection.
+	flushCurrent := func() {
+		if current.Len() == 0 {
+			return
+		}
+		tokens = append(tokens, sqlToken{text: strings.ToUpper(current.String()), start: tokenStart, end: tokenStart + current.Len()})
+		current.Reset()
+		tokenStart = -1
+	}
+
+	inSingleQuote := false
+	inDoubleQuote := false
+	inLineComment := false
+	inBlockComment := false
+	dollarTag := ""
+
+	for i := 0; i < len(statement); i++ {
+		ch := statement[i]
+
+		if inLineComment {
+			if ch == '\n' || ch == '\r' {
+				inLineComment = false
+			}
+			continue
+		}
+
+		if inBlockComment {
+			if ch == '*' && i+1 < len(statement) && statement[i+1] == '/' {
+				i++
+				inBlockComment = false
+			}
+			continue
+		}
+
+		if inSingleQuote {
+			if ch == '\'' {
+				if i+1 < len(statement) && statement[i+1] == '\'' {
+					i++
+					continue
+				}
+				inSingleQuote = false
+			}
+			continue
+		}
+
+		if inDoubleQuote {
+			if ch == '"' {
+				if i+1 < len(statement) && statement[i+1] == '"' {
+					i++
+					continue
+				}
+				inDoubleQuote = false
+			}
+			continue
+		}
+
+		if dollarTag != "" {
+			if i+len(dollarTag) <= len(statement) && statement[i:i+len(dollarTag)] == dollarTag {
+				i += len(dollarTag) - 1
+				dollarTag = ""
+			}
+			continue
+		}
+
+		if ch == '\'' {
+			flushCurrent()
+			inSingleQuote = true
+			continue
+		}
+
+		if ch == '"' {
+			flushCurrent()
+			inDoubleQuote = true
+			continue
+		}
+
+		if ch == '-' && i+1 < len(statement) && statement[i+1] == '-' {
+			flushCurrent()
+			i++
+			inLineComment = true
+			continue
+		}
+
+		if ch == '/' && i+1 < len(statement) {
+			next := statement[i+1]
+			if next == '*' {
+				flushCurrent()
+				i++
+				inBlockComment = true
+				continue
+			}
+			if next == '/' {
+				flushCurrent()
+				i++
+				inLineComment = true
+				continue
+			}
+		}
+
+		if ch == '$' {
+			if tag, length, ok := readDollarTag(statement, i); ok {
+				flushCurrent()
+				dollarTag = tag
+				i += length - 1
+				continue
+			}
+		}
+
+		if (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') ||
+			(ch >= '0' && ch <= '9') || ch == '_' {
+			if tokenStart < 0 {
+				tokenStart = i
+			}
+			current.WriteByte(ch)
+			continue
+		}
+
+		flushCurrent()
+	}
+
+	flushCurrent()
+	return tokens
+}
+
+func skipSQLTrivia(statement string, pos int) int {
+	for pos < len(statement) {
+		ch := statement[pos]
+		if ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' || ch == '\f' {
+			pos++
+			continue
+		}
+
+		if ch == '-' && pos+1 < len(statement) && statement[pos+1] == '-' {
+			pos += 2
+			for pos < len(statement) && statement[pos] != '\n' && statement[pos] != '\r' {
+				pos++
+			}
+			continue
+		}
+
+		if ch == '/' && pos+1 < len(statement) && statement[pos+1] == '*' {
+			pos += 2
+			for pos+1 < len(statement) {
+				if statement[pos] == '*' && statement[pos+1] == '/' {
+					pos += 2
+					break
+				}
+				pos++
+			}
+			continue
+		}
+
+		break
+	}
+
+	return pos
+}
+
+func parseQuotedLocalPath(statement string, pos int) (string, int, bool) {
+	if pos >= len(statement) || statement[pos] != '\'' {
+		return "", pos, false
+	}
+
+	pos++
+	var raw strings.Builder
+	for pos < len(statement) {
+		ch := statement[pos]
+		if ch == '\'' {
+			if pos+1 < len(statement) && statement[pos+1] == '\'' {
+				raw.WriteByte('\'')
+				pos += 2
+				continue
+			}
+			pos++
+			return raw.String(), pos, true
+		}
+		raw.WriteByte(ch)
+		pos++
+	}
+
+	return "", pos, false
+}
+
+func analyzeLocalCopyStatement(statement string) (localCopyAnalysis, bool) {
+	tokens := topLevelSQLTokens(statement)
+	if len(tokens) == 0 || tokens[0].text != "COPY" {
+		return localCopyAnalysis{}, false
+	}
+
+	fromLocalIdx := -1
+	for i := 1; i+1 < len(tokens); i++ {
+		if tokens[i].text == "FROM" && tokens[i+1].text == "LOCAL" {
+			fromLocalIdx = i
+			break
+		}
+	}
+	if fromLocalIdx < 0 {
+		return localCopyAnalysis{}, false
+	}
+
+	analysis := localCopyAnalysis{fromStart: tokens[fromLocalIdx].start, paths: make([]string, 0, 1)}
+	pos := skipSQLTrivia(statement, tokens[fromLocalIdx+1].end)
+
+	for {
+		// Vertica LOCAL paths are SQL single-quoted literals. We parse one path,
+		// then continue parsing comma-separated path literals if present.
+		path, nextPos, ok := parseQuotedLocalPath(statement, pos)
+		if !ok {
+			return localCopyAnalysis{}, false
+		}
+		analysis.paths = append(analysis.paths, path)
+		analysis.suffixStart = nextPos
+
+		pos = skipSQLTrivia(statement, nextPos)
+		if pos < len(statement) && statement[pos] == ',' {
+			pos++
+			pos = skipSQLTrivia(statement, pos)
+			continue
+		}
+		break
+	}
+
+	if len(analysis.paths) == 0 {
+		return localCopyAnalysis{}, false
+	}
+
+	return analysis, true
+}
+
+func rewriteLocalCopyToSTDIN(statement string) (string, []string, bool) {
+	analysis, ok := analyzeLocalCopyStatement(statement)
+	if !ok {
+		return statement, nil, false
+	}
+	// Keep the original suffix exactly as-is (including spacing/comments) to
+	// avoid collapsing tokens such as STDINPARSER or STDINDELIMITER.
+	rewritten := statement[:analysis.fromStart] + "FROM STDIN" + statement[analysis.suffixStart:]
+	return rewritten, analysis.paths, true
+}
+
+func readDollarTag(query string, start int) (string, int, bool) {
+	if query[start] != '$' {
+		return "", 0, false
+	}
+
+	end := start + 1
+	for end < len(query) {
+		r := rune(query[end])
+		if query[end] == '$' {
+			return query[start : end+1], end + 1 - start, true
+		}
+		if !isDollarTagRune(r) {
+			break
+		}
+		end++
+	}
+
+	return "", 0, false
+}
+
+func isDollarTagRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_'
 }
 
 func (s *stmt) prepareAndDescribe() error {

--- a/stmt.go
+++ b/stmt.go
@@ -895,9 +895,38 @@ func analyzeLocalCopyStatement(statement string) (localCopyAnalysis, bool) {
 	return analysis, true
 }
 
+// isBinaryOrCompressedFormat checks if the COPY statement uses a format
+// that cannot safely concatenate multiple files with newline delimiters.
+// Binary and compressed formats (Avro, Parquet, ORC, GZIP, BZIP2) require
+// native file boundary handling and cannot be safely merged as text streams.
+func isBinaryOrCompressedFormat(statement string) bool {
+	lowerStmt := strings.ToUpper(statement)
+	binaryFormats := []string{
+		"PARQUET", "ORC", "AVRO",
+	}
+	for _, format := range binaryFormats {
+		if strings.Contains(lowerStmt, format) {
+			return true
+		}
+	}
+	// Check for compression hints
+	compressors := []string{"GZIP", "BZIP2", "BZIP", "ZSTD"}
+	for _, comp := range compressors {
+		if strings.Contains(lowerStmt, comp) {
+			return true
+		}
+	}
+	return false
+}
+
 func rewriteLocalCopyToSTDIN(statement string) (string, []string, bool) {
 	analysis, ok := analyzeLocalCopyStatement(statement)
 	if !ok {
+		return statement, nil, false
+	}
+	// Multi-file LOCAL COPY is only safe for text-based formats (CSV, JSON, TSV, etc.)
+	// Binary and compressed formats require native file boundary handling.
+	if len(analysis.paths) > 1 && isBinaryOrCompressedFormat(statement) {
 		return statement, nil, false
 	}
 	// Keep the original suffix exactly as-is (including spacing/comments) to

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -279,6 +279,147 @@ func TestNumInput(t *testing.T) {
 	}
 }
 
+func TestIsLocalCopyStatementVariants(t *testing.T) {
+	testCases := []struct {
+		name     string
+		query    string
+		expected bool
+	}{
+		{
+			name:     "leading line comment",
+			query:    "-- daily load\nCOPY t1 FROM LOCAL '/tmp/copy_functionality_files/f1.csv' DELIMITER ',';",
+			expected: true,
+		},
+		{
+			name:     "leading whitespace",
+			query:    "\n\n COPY t1 FROM LOCAL '/tmp/copy_functionality_files/f1.csv' DELIMITER ',';",
+			expected: true,
+		},
+		{
+			name:     "tabs between keywords",
+			query:    "COPY t1 FROM\tLOCAL\t'/tmp/copy_functionality_files/f1.csv' DELIMITER ',';",
+			expected: true,
+		},
+		{
+			name:     "block comment between from and local",
+			query:    "COPY t1 FROM /*note*/ LOCAL '/tmp/copy_functionality_files/f1.csv' DELIMITER ',';",
+			expected: true,
+		},
+		{
+			name:     "line comment between from and local",
+			query:    "COPY t1 FROM --note\nLOCAL '/tmp/copy_functionality_files/f1.csv' DELIMITER ',';",
+			expected: true,
+		},
+		{
+			name: "multiple local files",
+			query: "COPY local_file_tests FROM LOCAL '/home/release/siva/mountains.json', "+
+				"'/home/release/siva/mountains1.json' PARSER FJSONPARSER() REJECTED DATA AS TABLE local_file_tests_rejects;",
+			expected: true,
+		},
+		{
+			name:     "copy token in string literal",
+			query:    "SELECT 'COPY t1 FROM LOCAL ''/tmp/f1.csv''' AS txt;",
+			expected: false,
+		},
+		{
+			name:     "multiple statements",
+			query:    "SELECT 1; COPY t1 FROM LOCAL '/tmp/copy_functionality_files/f1.csv';",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := testStatement(tc.query)
+			if got := s.isLocalCopyStatement(); got != tc.expected {
+				t.Fatalf("expected %v, got %v", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestRewriteLocalCopyToSTDINVariants(t *testing.T) {
+	testCases := []struct {
+		name          string
+		query         string
+		expectedSQL   string
+		expectedPaths []string
+		expectedLocal bool
+	}{
+		{
+			name:          "simple local copy",
+			query:         "COPY t1 FROM LOCAL '/tmp/f1.csv' DELIMITER ',';",
+			expectedSQL:   "COPY t1 FROM STDIN DELIMITER ',';",
+			expectedPaths: []string{"/tmp/f1.csv"},
+			expectedLocal: true,
+		},
+		{
+			name:          "tabs around local",
+			query:         "COPY t1 FROM\tLOCAL\t'/tmp/f1.csv' DELIMITER ',';",
+			expectedSQL:   "COPY t1 FROM STDIN DELIMITER ',';",
+			expectedPaths: []string{"/tmp/f1.csv"},
+			expectedLocal: true,
+		},
+		{
+			name:          "block comment between from local",
+			query:         "COPY t1 FROM /*note*/ LOCAL '/tmp/f1.csv' DELIMITER ',';",
+			expectedSQL:   "COPY t1 FROM STDIN DELIMITER ',';",
+			expectedPaths: []string{"/tmp/f1.csv"},
+			expectedLocal: true,
+		},
+		{
+			name:          "line comment between from local",
+			query:         "COPY t1 FROM --note\nLOCAL '/tmp/f1.csv' DELIMITER ',';",
+			expectedSQL:   "COPY t1 FROM STDIN DELIMITER ',';",
+			expectedPaths: []string{"/tmp/f1.csv"},
+			expectedLocal: true,
+		},
+		{
+			name: "multiple local files",
+			query: "COPY local_file_tests FROM LOCAL '/home/release/siva/mountains.json', "+
+				"'/home/release/siva/mountains1.json' PARSER FJSONPARSER() REJECTED DATA AS TABLE local_file_tests_rejects;",
+			expectedSQL: "COPY local_file_tests FROM STDIN PARSER FJSONPARSER() "+
+				"REJECTED DATA AS TABLE local_file_tests_rejects;",
+			expectedPaths: []string{"/home/release/siva/mountains.json", "/home/release/siva/mountains1.json"},
+			expectedLocal: true,
+		},
+		{
+			name:          "preserve comment between list and clause",
+			query:         "COPY t1 FROM LOCAL '/tmp/f1.csv' /*after*/ DELIMITER ',';",
+			expectedSQL:   "COPY t1 FROM STDIN /*after*/ DELIMITER ',';",
+			expectedPaths: []string{"/tmp/f1.csv"},
+			expectedLocal: true,
+		},
+		{
+			name:          "non local copy statement",
+			query:         "SELECT 1;",
+			expectedSQL:   "SELECT 1;",
+			expectedPaths: nil,
+			expectedLocal: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rewritten, paths, isLocal := rewriteLocalCopyToSTDIN(tc.query)
+			if isLocal != tc.expectedLocal {
+				t.Fatalf("expected isLocal=%v got %v", tc.expectedLocal, isLocal)
+			}
+			if rewritten != tc.expectedSQL {
+				t.Fatalf("expected SQL %q got %q", tc.expectedSQL, rewritten)
+			}
+			if len(paths) != len(tc.expectedPaths) {
+				t.Fatalf("expected %d paths got %d", len(tc.expectedPaths), len(paths))
+			}
+			for i := range paths {
+				if paths[i] != tc.expectedPaths[i] {
+					t.Fatalf("path[%d] expected %q got %q", i, tc.expectedPaths[i], paths[i])
+				}
+			}
+		})
+	}
+}
+
 func TestMergeRowSets(t *testing.T) {
 	single := newEmptyRows()
 	multiA := newEmptyRows()

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -384,6 +384,27 @@ func TestRewriteLocalCopyToSTDINVariants(t *testing.T) {
 			expectedLocal: true,
 		},
 		{
+			name:          "multiple local files avro is rejected",
+			query:         "COPY t1 FROM LOCAL '/tmp/f1.avro', '/tmp/f2.avro' PARSER FAVROPARSER();",
+			expectedSQL:   "COPY t1 FROM LOCAL '/tmp/f1.avro', '/tmp/f2.avro' PARSER FAVROPARSER();",
+			expectedPaths: nil,
+			expectedLocal: false,
+		},
+		{
+			name:          "multiple local files gzip is rejected",
+			query:         "COPY t1 FROM LOCAL '/tmp/f1.csv.gz', '/tmp/f2.csv.gz' GZIP DELIMITER ',';",
+			expectedSQL:   "COPY t1 FROM LOCAL '/tmp/f1.csv.gz', '/tmp/f2.csv.gz' GZIP DELIMITER ',';",
+			expectedPaths: nil,
+			expectedLocal: false,
+		},
+		{
+			name:          "single local file avro is allowed",
+			query:         "COPY t1 FROM LOCAL '/tmp/f1.avro' PARSER FAVROPARSER();",
+			expectedSQL:   "COPY t1 FROM STDIN PARSER FAVROPARSER();",
+			expectedPaths: []string{"/tmp/f1.avro"},
+			expectedLocal: true,
+		},
+		{
 			name:          "preserve comment between list and clause",
 			query:         "COPY t1 FROM LOCAL '/tmp/f1.csv' /*after*/ DELIMITER ',';",
 			expectedSQL:   "COPY t1 FROM STDIN /*after*/ DELIMITER ',';",


### PR DESCRIPTION
Overview
Adds support for SQL formatting variations in COPY ... FROM LOCAL statements and enables comma-separated multi-file COPY operations.

Changes:
Core Features:
SQL Formatting Variations: Supports leading comments, whitespace, tabs, and inline/line comments between keywords in COPY statements
Record Boundary Preservation: Inserts newlines between files only when needed to prevent record merging
Protocol Flow Fixes: Drains backend messages after errors to eliminate "unhandled message" warnings
Modified Files:
```
[stmt.go]: Added tokenizer, path parser, stream concatenation, and file handlers
[connection.go]: Added drainUntilReady() message consumer
[driver_test.go]: 5 new integration tests for multi-file and SQL variants
[stmt_test.go]: 2 unit tests for SQL variant detection

```
Tests Added
Unit Tests:
```
[TestIsLocalCopyStatementVariants]: Validates LOCAL COPY detection across formatting styles
[TestRewriteLocalCopyToSTDINVariants]: Validates single/multi-file path extraction

```
Integration Tests:
```
[TestLocalCopySQLVariants]: Leading comments, whitespace, tabs, inline comments, line comments
[TestLocalCopyCSVMultipleFiles]: 3-file COPY with record boundary validation
[TestLocalCopyCSVMultipleFilesMissingFile]: Error handling for missing files
[TestLocalCopyCSVMultipleFilesSchemaMismatch]: Error handling for schema mismatches
[TestLocalCopyJSONMultipleFiles]: 2-file JSON COPY with parser

```
Technical Notes
Simple query protocol only (prepared statements incompatible with LOCAL COPY state)
Multi-file streams rewritten as single STDIN for protocol compatibility
No breaking changes; all existing tests pass
